### PR TITLE
fix(routing): stop unowned artist/album pages from looping on the library endpoint

### DIFF
--- a/frontend/src/routes/album/[id]/+page.svelte
+++ b/frontend/src/routes/album/[id]/+page.svelte
@@ -26,7 +26,16 @@
 	});
 </script>
 
-{#if localQuery.isLoading || shouldRedirect}
+<!--
+	Gate the skeleton on `!isFetched` (monotonic once the library lookup first
+	resolves), NOT on `isLoading` alone. ProviderAlbumPage re-observes this same
+	library query for its MusicBrainz-down fallback; for an unowned album that
+	404s, its mount kicks off a refetch that flips `isLoading`/`status:pending`
+	back on. Gating on `isLoading` alone would swap back to the skeleton, unmount
+	the provider page, cancel that refetch, and remount - an infinite loop that
+	hammers /api/v1/library/albums/{id} (see GH-339 / GH-341).
+-->
+{#if (localQuery.isLoading && !localQuery.isFetched) || shouldRedirect}
 	<div class="w-full max-w-7xl mx-auto px-2 py-4 sm:px-4 sm:py-8 lg:px-8">
 		<div class="grid gap-6 lg:grid-cols-[20rem_1fr]">
 			<div class="skeleton aspect-square w-full rounded-box"></div>

--- a/frontend/src/routes/album/[id]/routing.svelte.spec.ts
+++ b/frontend/src/routes/album/[id]/routing.svelte.spec.ts
@@ -9,7 +9,10 @@ const h = vi.hoisted(() => ({
 	album: {
 		id: 'local-album-id',
 		musicbrainz_release_group_id: 'provider-album-id' as string | null
-	}
+	},
+	// Mocked TanStack result the dispatcher reads. `isFetched` is the monotonic
+	// flag the skeleton gate depends on (see the not-in-library cases below).
+	query: { data: undefined as unknown, isLoading: false, isFetched: true }
 }));
 
 vi.mock('$app/navigation', () => ({
@@ -34,10 +37,7 @@ vi.mock('./ProviderAlbumPage.svelte', () => {
 
 vi.mock('$lib/queries/library/LibraryQueries.svelte', async (importOriginal) => ({
 	...(await importOriginal<typeof import('$lib/queries/library/LibraryQueries.svelte')>()),
-	getLibraryAlbumDetailQuery: () => ({
-		data: h.album,
-		isLoading: false
-	}),
+	getLibraryAlbumDetailQuery: () => h.query,
 	cacheCanonicalLibraryAlbumDetail: (...args: unknown[]) => h.cache(...args)
 }));
 
@@ -46,6 +46,7 @@ import AlbumPage from './+page.svelte';
 beforeEach(() => {
 	vi.clearAllMocks();
 	h.album.musicbrainz_release_group_id = 'provider-album-id';
+	h.query = { data: h.album, isLoading: false, isFetched: true };
 });
 
 it('keeps a linked album on its MusicBrainz release-group route', async () => {
@@ -83,4 +84,35 @@ it('keeps a local-only album on its local route', async () => {
 	await vi.waitFor(() => expect(h.goto).not.toHaveBeenCalled());
 	expect(h.localView).toHaveBeenCalled();
 	expect(h.providerView).not.toHaveBeenCalled();
+});
+
+it('shows the loading skeleton only on the first library fetch', async () => {
+	// Nothing resolved yet: no data, no error, first fetch in flight.
+	h.query = { data: undefined, isLoading: true, isFetched: false };
+	render(AlbumPage, {
+		props: { data: { albumId: 'unowned-album-mbid' } }
+	} as unknown as Parameters<typeof render>[1]);
+
+	// Skeleton branch: neither the local nor the provider page is mounted.
+	await vi.waitFor(() => expect(h.providerView).not.toHaveBeenCalled());
+	expect(h.localView).not.toHaveBeenCalled();
+	expect(h.goto).not.toHaveBeenCalled();
+});
+
+it('renders the provider page for an unowned album while its 404 library query refetches', async () => {
+	// GH-339 / GH-341: for an album not in the library the detail endpoint 404s.
+	// ProviderAlbumPage re-observes that same query for its MusicBrainz-down
+	// fallback, so the errored query is refetched and reports isLoading=true with
+	// no data. Gating the skeleton on isLoading alone would swap back to the
+	// skeleton, unmount the provider page, cancel the refetch and remount - an
+	// infinite loop. isFetched stays true once the query has resolved once, so the
+	// provider page must stay put.
+	h.query = { data: undefined, isLoading: true, isFetched: true };
+	render(AlbumPage, {
+		props: { data: { albumId: 'unowned-album-mbid' } }
+	} as unknown as Parameters<typeof render>[1]);
+
+	await vi.waitFor(() => expect(h.providerView).toHaveBeenCalled());
+	expect(h.localView).not.toHaveBeenCalled();
+	expect(h.goto).not.toHaveBeenCalled();
 });

--- a/frontend/src/routes/artist/[id]/+page.svelte
+++ b/frontend/src/routes/artist/[id]/+page.svelte
@@ -27,7 +27,16 @@
 	});
 </script>
 
-{#if localQuery.isLoading || shouldRedirect}
+<!--
+	Gate the skeleton on `!isFetched` (monotonic once the library lookup first
+	resolves), NOT on `isLoading` alone. ProviderArtistPage re-observes this same
+	library query for its MusicBrainz-down fallback; for an unowned artist that
+	404s, its mount kicks off a refetch that flips `isLoading`/`status:pending`
+	back on. Gating on `isLoading` alone would swap back to the skeleton, unmount
+	the provider page, cancel that refetch, and remount - an infinite loop that
+	hammers /api/v1/library/artists/{id} (see GH-339 / GH-341).
+-->
+{#if (localQuery.isLoading && !localQuery.isFetched) || shouldRedirect}
 	<div class="w-full max-w-7xl mx-auto px-2 py-4 sm:px-4 sm:py-8 lg:px-8">
 		<div class="flex items-end gap-6">
 			<div class="skeleton h-48 w-48 rounded-full"></div>

--- a/frontend/src/routes/artist/[id]/routing.svelte.spec.ts
+++ b/frontend/src/routes/artist/[id]/routing.svelte.spec.ts
@@ -9,7 +9,10 @@ const h = vi.hoisted(() => ({
 	artist: {
 		id: 'local-artist-id',
 		musicbrainz_artist_id: 'provider-artist-id' as string | null
-	}
+	},
+	// Mocked TanStack result the dispatcher reads. `isFetched` is the monotonic
+	// flag the skeleton gate depends on (see the not-in-library cases below).
+	query: { data: undefined as unknown, isLoading: false, isFetched: true }
 }));
 
 vi.mock('$app/navigation', () => ({
@@ -34,10 +37,7 @@ vi.mock('./ProviderArtistPage.svelte', () => {
 
 vi.mock('$lib/queries/library/LibraryQueries.svelte', async (importOriginal) => ({
 	...(await importOriginal<typeof import('$lib/queries/library/LibraryQueries.svelte')>()),
-	getLibraryArtistDetailQuery: () => ({
-		data: h.artist,
-		isLoading: false
-	}),
+	getLibraryArtistDetailQuery: () => h.query,
 	cacheCanonicalLibraryArtistDetail: (...args: unknown[]) => h.cache(...args)
 }));
 
@@ -47,6 +47,7 @@ import ArtistPage from './+page.svelte';
 beforeEach(() => {
 	vi.clearAllMocks();
 	h.artist.musicbrainz_artist_id = 'provider-artist-id';
+	h.query = { data: h.artist, isLoading: false, isFetched: true };
 });
 
 it('keeps a linked artist on its MusicBrainz route', async () => {
@@ -99,4 +100,45 @@ it('keeps a local-only artist on its local route', async () => {
 	await vi.waitFor(() => expect(h.goto).not.toHaveBeenCalled());
 	expect(h.localView).toHaveBeenCalled();
 	expect(h.providerView).not.toHaveBeenCalled();
+});
+
+it('shows the loading skeleton only on the first library fetch', async () => {
+	// Nothing resolved yet: no data, no error, first fetch in flight.
+	h.query = { data: undefined, isLoading: true, isFetched: false };
+	render(ArtistPage, {
+		props: {
+			data: {
+				artistId: 'unowned-artist-mbid',
+				primarySource: 'listenbrainz' as MusicSource
+			}
+		}
+	} as unknown as Parameters<typeof render>[1]);
+
+	// Skeleton branch: neither the local nor the provider page is mounted.
+	await vi.waitFor(() => expect(h.providerView).not.toHaveBeenCalled());
+	expect(h.localView).not.toHaveBeenCalled();
+	expect(h.goto).not.toHaveBeenCalled();
+});
+
+it('renders the provider page for an unowned artist while its 404 library query refetches', async () => {
+	// GH-339 / GH-341: for an artist not in the library the detail endpoint 404s.
+	// ProviderArtistPage re-observes that same query for its MusicBrainz-down
+	// fallback, so the errored query is refetched and reports isLoading=true with
+	// no data. Gating the skeleton on isLoading alone would swap back to the
+	// skeleton, unmount the provider page, cancel the refetch and remount - an
+	// infinite loop. isFetched stays true once the query has resolved once, so the
+	// provider page must stay put.
+	h.query = { data: undefined, isLoading: true, isFetched: true };
+	render(ArtistPage, {
+		props: {
+			data: {
+				artistId: 'unowned-artist-mbid',
+				primarySource: 'listenbrainz' as MusicSource
+			}
+		}
+	} as unknown as Parameters<typeof render>[1]);
+
+	await vi.waitFor(() => expect(h.providerView).toHaveBeenCalled());
+	expect(h.localView).not.toHaveBeenCalled();
+	expect(h.goto).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
Fixes #339. Fixes #341.

## Summary

Clicking an artist or album that is **not** in the local library showed a
loading skeleton that never completed and fired `/api/v1/library/artists/{mbid}`
(or `/albums/{mbid}`) in a tight loop — roughly 30 requests/second; #341
measured ~1,700 requests in 52 seconds — even though the backend correctly
answered `404 NOT_FOUND` every time. The catalog (MusicBrainz) page for unowned
content was therefore unreachable.

## Root cause

The artist and album route dispatchers
(`frontend/src/routes/{artist,album}/[id]/+page.svelte`) fetch a library-detail
query to decide between the **local** page and the **provider** (MusicBrainz
catalog) page, and gate the loading skeleton on `localQuery.isLoading`.

For an unowned entity the library query returns 404, so the dispatcher correctly
falls through to `ProviderArtistPage` / `ProviderAlbumPage`. But those provider
pages **re-observe the same library-detail query** for their "MusicBrainz-down"
degraded fallback (`ProviderArtistPage.svelte:124`, `ProviderAlbumPage.svelte:38`).

That creates a feedback loop:

1. Dispatcher's library query 404s → `isLoading` false → renders the provider page.
2. The provider page mounts and adds a **second observer** to the same errored query.
3. A new observer on an errored (always-stale) query triggers a **refetch**, which
   flips the dispatcher's `isLoading` / `status:pending` back on.
4. The dispatcher swaps back to the **skeleton** and **unmounts** the provider page.
5. Unmounting removes the observer and **cancels** the in-flight refetch, so the
   404 never settles (the query is stuck `pending`).
6. `isLoading` goes false again → the dispatcher re-renders the provider page → back to step 2.

This only affected unowned entities, because that is the only path that mounts the
provider page — owned entities render the local page, and the query succeeds and
stays cached. It's also why `staleTime` appeared to have "no effect" and the query
key looked "unstable" in #341: the query was being torn down and refetched on every
mount/unmount cycle, never reaching a settled state.

## The fix

Gate the skeleton on a **monotonic** signal instead of the live loading flag:

```svelte
{#if (localQuery.isLoading && !localQuery.isFetched) || shouldRedirect}
```

`isFetched` is backed by TanStack Query's ever-incrementing data/error update
counts, so it latches `true` the first time the library lookup resolves (success
**or** error) and never reverts — even when a later refetch is cancelled. Once the
lookup has resolved once, the skeleton can no longer reappear, the provider page
stays mounted, its refetch settles to the 404, and the catalog page renders.

Applied identically to both dispatchers, each with a comment explaining the
reactive footgun so it isn't "simplified" back into a loop.

## Tests

The existing `routing.svelte.spec.ts` cases only ever supplied `data` (the
in-library path), so the **not-in-library path had zero coverage** — which is how
this regression shipped. This PR extends both routing specs (no new files, same
mock-the-query style already used there) with the missing coverage:

- **first library fetch** (no data, `isFetched: false`) → shows the skeleton
- **unowned entity whose 404 query is refetching** (no data, `isFetched: true`) →
  renders the provider page and keeps it mounted

Both new "refetching" cases fail on the pre-fix gate and pass with the fix.

## Verification

- Reproduced the live loop in a real browser during investigation: **2,358**
  library requests in 1.5s before the fix → **2** after.
- New regression tests: fail on the reverted gate, pass with the fix.
- Full frontend suite: **253 files / 2,119 tests** passing.
- `eslint` clean; `svelte-check` clean (0 errors, 0 warnings).

## Files changed

| File | Change |
| --- | --- |
| `frontend/src/routes/artist/[id]/+page.svelte` | Gate skeleton on `!isFetched` (+ comment) |
| `frontend/src/routes/album/[id]/+page.svelte` | Gate skeleton on `!isFetched` (+ comment) |
| `frontend/src/routes/artist/[id]/routing.svelte.spec.ts` | Add not-in-library coverage |
| `frontend/src/routes/album/[id]/routing.svelte.spec.ts` | Add not-in-library coverage |

## Notes / out of scope

#341 also mentions a broken docs link in the MusicBrainz settings
(`/docs/musicbrainz-mirror-selfhosting.md`). That's unrelated to this loop and is
left for a separate change.

## AI disclosure

AI found and fixed the bug and wrote the PR body above. I then took these changes and rolled them out to my environment and tested them. I'm not much of a frontend dev, but these changes generally look correct to me and I understand what they're doing at least.