### PR TITLE
fix(acquisition): use expected_tracks when a manifest has no target_files

### DIFF
--- a/backend/services/native/download_orchestrator.py
+++ b/backend/services/native/download_orchestrator.py
@@ -1880,7 +1880,15 @@ class DownloadOrchestrator:
                 and result.management_hold_reason_code is None
             ):
                 try:
-                    asked = len(self._read_manifest(task.id).target_files)
+                    manifest = self._read_manifest(task.id)
+                    # A Usenet grab is one opaque NZB, so its manifest carries no
+                    # per-file entries (acquisition/strategy.py builds it with
+                    # ``target_files=[]``) and the requested tracklist is what this
+                    # source was asked for. Reading ``target_files`` alone makes
+                    # ``asked`` 0 for every Usenet album, which then always trips the
+                    # ``asked < task.track_count`` under-delivery test below and
+                    # defeats this exception on that path entirely.
+                    asked = len(manifest.target_files) or len(manifest.expected_tracks)
                 except OrchestrationError:
                     asked = None
                 rows = []

--- a/backend/tests/services/test_download_orchestrator.py
+++ b/backend/tests/services/test_download_orchestrator.py
@@ -3941,3 +3941,85 @@ async def test_failover_requests_only_missing_tracks_from_next_peer(tmp_path: Pa
     assert second_files == ["p2/02.flac"]
     final = await store.get_task(task.id)
     assert final.status == "completed"
+
+
+# Delivery-trust exception (#131 family) on the Usenet path.
+#
+# A Usenet grab is one opaque NZB, so its manifest is built with target_files=[]
+# (acquisition/strategy.py) and carries the requested edition in expected_tracks
+# instead. The delivery-trust exception in _download_is_complete sized "what this
+# source was asked for" from target_files alone, making it 0 for every Usenet album;
+# `asked < task.track_count` was then always true, the exception never fired, and a
+# complete correct import was declared under-delivered -> quarantined -> re-downloaded
+# in a loop that never terminates.
+
+
+def _write_album_manifest(orch, task_id, *, target_files, expected_tracks):
+    manifest = DownloadManifest(
+        task_id=task_id,
+        release_group_mbid="rg-1",
+        artist_name="Artist",
+        album_title="Album",
+        naming_template=_TEMPLATE,
+        target_files=target_files,
+        expected_tracks=expected_tracks,
+    )
+    path = orch._staging / task_id / "manifest.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(ManifestCodec().encode(manifest))
+
+
+@pytest.mark.asyncio
+async def test_usenet_full_delivery_completes_when_release_group_has_no_rows(
+    tmp_path: Path,
+):
+    """target_files=[] must not read as 'this source was asked for nothing'."""
+    store, orch, _fp, _lib = _build(tmp_path)
+    task = await _new_task(store, track_count=16)
+    _write_album_manifest(
+        orch,
+        task.id,
+        target_files=[],
+        expected_tracks=[ExpectedTrack(track_number=n) for n in range(1, 17)],
+    )
+    orch._coverage = AsyncMock(return_value=(0, 16, []))
+    result = ProcessResult(
+        succeeded=[f"/lib/{n:02d}.flac" for n in range(1, 17)], failed=[]
+    )
+
+    assert await orch._download_is_complete(task, True, result) is True
+
+
+@pytest.mark.asyncio
+async def test_usenet_short_delivery_still_fails_over(tmp_path: Path):
+    """The under-delivery veto must survive: fewer files than the edition asked for."""
+    store, orch, _fp, _lib = _build(tmp_path)
+    task = await _new_task(store, track_count=16)
+    _write_album_manifest(
+        orch,
+        task.id,
+        target_files=[],
+        expected_tracks=[ExpectedTrack(track_number=n) for n in range(1, 17)],
+    )
+    orch._coverage = AsyncMock(return_value=(0, 16, []))
+    result = ProcessResult(succeeded=[f"/lib/{n:02d}.flac" for n in range(1, 6)], failed=[])
+
+    assert await orch._download_is_complete(task, True, result) is False
+
+
+@pytest.mark.asyncio
+async def test_soulseek_short_manifest_still_fails_over(tmp_path: Path):
+    """Soulseek behaviour is unchanged: a manifest smaller than the requested
+    tracklist under-delivered even when every file published cleanly."""
+    store, orch, _fp, _lib = _build(tmp_path)
+    task = await _new_task(store, track_count=16)
+    _write_album_manifest(
+        orch,
+        task.id,
+        target_files=[ExpectedFile(filename=f"{n:02d}.flac", size=1) for n in range(1, 6)],
+        expected_tracks=[ExpectedTrack(track_number=n) for n in range(1, 17)],
+    )
+    orch._coverage = AsyncMock(return_value=(0, 16, []))
+    result = ProcessResult(succeeded=[f"/lib/{n:02d}.flac" for n in range(1, 6)], failed=[])
+
+    assert await orch._download_is_complete(task, True, result) is False


### PR DESCRIPTION
An NZB is one opaque unit, so acquisition/strategy.py builds Usenet manifests with target_files=[] and carries the requested edition in expected_tracks. The delivery-trust exception in _download_is_complete sized `asked` from target_files alone, so asked was 0 for every Usenet album, `asked < task.track_count` always held, and the exception could never fire on that path.

Effect: a complete album imports all N files, coverage then reports covered=0, the task is quarantined verify_failed, and failover downloads another edition. Repeats until candidates are exhausted, leaving duplicate editions on disk. The files are present throughout and nothing in the log reports success.

Fall back to expected_tracks when target_files is empty. Soulseek manifests list individual files, so the fallback never engages there.

Tested on 2.8.0 against Tidarr's SABnzbd-compatible API. Three albums that had been looping for days completed on the first attempt:

  matched=13/13 covered=0 delivery_complete delivered=13 manifest_files=13
  matched=6/6   covered=0 delivery_complete delivered=6  manifest_files=6
  matched=25/25 covered=0 delivery_complete delivered=25 manifest_files=25

manifest_files is `asked`, and reads 0 on unpatched code. Three other downloads in the same run were still quarantined on matched (genuinely wrong albums), so the under-delivery veto is unchanged.

Tests: full Usenet delivery with no rows completes; short Usenet delivery fails
over; short Soulseek manifest fails over. test_download_orchestrator.py: 129 passed.

## What

## Why

## Testing

- [X] I have tested these changes locally
- [ ] I have added or updated tests

## AI-Assisted Contributions

Claude diagnosed the cause, wrote the one-line change and the three regression tests. I ran the tests and verified the fix on my own instance before submitting.

## Checklist

- [ ] Backend lint passes            <- pending ruff above
- [ ] Backend tests pass             <- pending full suite; orchestrator suite is 129 passed
- [x] Frontend lint passes           n/a, no frontend changes
- [x] Frontend type check passes     n/a, no frontend changes
- [x] No `any` in TypeScript         n/a, no TypeScript changed
- [x] No hardcoded colors            n/a
- [x] All external API calls have timeouts   n/a, no new calls
- [x] New msgspec structs follow existing patterns   n/a, no new structs
- [x] TanStack Query used for all new data fetching  n/a, no data fetching
- [x] No secrets, tokens, or credentials in source