### PR TITLE
feat(navidrome): export playlists as .m3u8 for Navidrome to import

### DIFF
--- a/backend/api/v1/routes/settings.py
+++ b/backend/api/v1/routes/settings.py
@@ -12,6 +12,7 @@ from api.v1.schemas.settings import (
     JellyfinVerifyResponse,
     JellyfinUserInfo,
     NavidromeConnectionSettings,
+    NavidromePlaylistSyncResult,
     ListenBrainzConnectionSettings,
     YouTubeConnectionSettings,
     LastFmConnectionSettings,
@@ -48,6 +49,7 @@ from api.v1.schemas.advanced_settings import (
 )
 from core.dependencies import (
     get_events_watcher_getter,
+    get_navidrome_playlist_export_service,
     get_preferences_service,
     get_settings_service,
     get_oidc_user_auth_service,
@@ -368,6 +370,45 @@ async def update_navidrome_settings(
         raise HTTPException(
             status_code=400, detail="Navidrome settings are incomplete or invalid"
         )
+
+
+@router.post(
+    "/navidrome/playlist-sync", response_model=NavidromePlaylistSyncResult
+)
+async def sync_navidrome_playlists(
+    preferences_service: PreferencesService = Depends(get_preferences_service),
+    export_service: "NavidromePlaylistExportService" = Depends(
+        get_navidrome_playlist_export_service
+    ),
+):
+    """Write DroppedNeedle playlists into the configured directory.
+
+    No request body: the target comes from saved settings, so no caller can
+    name an arbitrary directory to write into.
+    """
+    settings = preferences_service.get_navidrome_connection()
+    if not settings.playlist_sync_enabled:
+        return NavidromePlaylistSyncResult(
+            success=False,
+            message="Playlist sync is turned off. Enable it and save first.",
+        )
+    result = await export_service.sync(
+        target_dir=settings.playlist_sync_path,
+        scope=settings.playlist_sync_scope,
+        remove_deleted=settings.playlist_sync_remove_deleted,
+    )
+    return NavidromePlaylistSyncResult(
+        success=result.success,
+        message=result.message,
+        written=result.written,
+        unchanged=result.unchanged,
+        removed=result.removed,
+        removal_failures=result.removal_failures,
+        skipped_empty=result.skipped_empty,
+        skipped_not_ours=result.skipped_not_ours,
+        tracks_missing_files=result.tracks_missing_files,
+        tracks_unrepresentable=result.tracks_unrepresentable,
+    )
 
 
 @router.post("/navidrome/verify", response_model=VerifyConnectionResponse)

--- a/backend/api/v1/schemas/settings.py
+++ b/backend/api/v1/schemas/settings.py
@@ -684,11 +684,36 @@ class NavidromeConnectionSettings(AppStruct):
     username: str = ""
     password: str = ""
     enabled: bool = False
+    # .m3u8 export into a directory Navidrome scans. Off by default.
+    playlist_sync_enabled: bool = False
+    playlist_sync_path: str = ""
+    # Navidrome shows imported playlists to everyone, so "all" is opt-in.
+    playlist_sync_scope: str = "public"
+    # Remove an exported file once its playlist stops qualifying.
+    playlist_sync_remove_deleted: bool = True
 
     def __post_init__(self) -> None:
         self.navidrome_url = (
             self.navidrome_url.rstrip("/") if self.navidrome_url else ""
         )
+        self.playlist_sync_path = (
+            self.playlist_sync_path.strip() if self.playlist_sync_path else ""
+        )
+        if self.playlist_sync_scope not in {"public", "all"}:
+            self.playlist_sync_scope = "public"
+
+
+class NavidromePlaylistSyncResult(AppStruct):
+    success: bool = False
+    message: str = ""
+    written: int = 0
+    unchanged: int = 0
+    removed: int = 0
+    removal_failures: int = 0
+    skipped_empty: int = 0
+    skipped_not_ours: int = 0
+    tracks_missing_files: int = 0
+    tracks_unrepresentable: int = 0
 
 
 class PlexConnectionSettings(AppStruct):

--- a/backend/core/dependencies/__init__.py
+++ b/backend/core/dependencies/__init__.py
@@ -142,6 +142,7 @@ from .service_providers import (  # noqa: F401
     get_edition_conversion_service,
     get_library_contribution_service,
     get_library_contribution_verification_worker,
+    get_navidrome_playlist_export_service,
     get_target_library_repository,
     get_target_genre_index,
     get_target_album_release_pin_store,

--- a/backend/core/dependencies/service_providers.py
+++ b/backend/core/dependencies/service_providers.py
@@ -164,6 +164,17 @@ def get_genre_artwork_service() -> "GenreArtworkService":
 
 
 @singleton
+def get_navidrome_playlist_export_service() -> "NavidromePlaylistExportService":
+    from services.navidrome_playlist_export_service import (
+        NavidromePlaylistExportService,
+    )
+
+    from .cache_providers import get_native_library_store
+
+    return NavidromePlaylistExportService(get_native_library_store())
+
+
+@singleton
 def get_target_library_repository() -> "TargetLibraryRepository":
     from services.native.target_library_repository import TargetLibraryRepository
 

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -124,6 +124,56 @@ async def cleanup_disk_cache_periodically(
             logger.error("Disk cache cleanup task failed: %s", e, exc_info=True)
 
 
+async def export_navidrome_playlists_periodically(
+    interval: int = 300,
+) -> None:
+    """Keep Navidrome's imported playlists in step with DroppedNeedle's.
+
+    Polled rather than hooked into every playlist mutation, so no edit path
+    can be missed. Unchanged files are not rewritten.
+    """
+    from core.dependencies import (
+        get_navidrome_playlist_export_service,
+        get_preferences_service,
+    )
+
+    while True:
+        try:
+            await asyncio.sleep(interval)
+            settings = get_preferences_service().get_navidrome_connection()
+            if not settings.playlist_sync_enabled or not settings.playlist_sync_path:
+                continue
+            result = await get_navidrome_playlist_export_service().sync(
+                target_dir=settings.playlist_sync_path,
+                scope=settings.playlist_sync_scope,
+                remove_deleted=settings.playlist_sync_remove_deleted,
+            )
+            if result.removal_failures:
+                logger.error(
+                    "Navidrome playlist export could not remove %d superseded "
+                    "playlist file(s); they remain visible in Navidrome and will "
+                    "be retried: %s",
+                    result.removal_failures,
+                    result.message,
+                )
+            elif not result.success:
+                logger.warning("Navidrome playlist export: %s", result.message)
+        except asyncio.CancelledError:
+            break
+        except Exception as e:
+            logger.error(
+                "Navidrome playlist export task failed: %s", e, exc_info=True
+            )
+
+
+def start_navidrome_playlist_export_task(interval: int = 300) -> asyncio.Task:
+    task = asyncio.create_task(
+        export_navidrome_playlists_periodically(interval=interval)
+    )
+    TaskRegistry.get_instance().register("navidrome-playlist-export", task)
+    return task
+
+
 def start_disk_cache_cleanup_task(
     disk_cache: DiskMetadataCache,
     interval: int = 600,

--- a/backend/infrastructure/persistence/native_library_store.py
+++ b/backend/infrastructure/persistence/native_library_store.py
@@ -5263,6 +5263,28 @@ class NativeLibraryStore(PersistenceBase):
 
         return await self._read(operation)
 
+    async def list_target_playlist_export_rows(
+        self, playlist_id: str
+    ) -> list[dict[str, Any]]:
+        """Ordered playlist entries joined to the local file each one plays.
+
+        Entries with no local track (Navidrome/Plex/YouTube) return a NULL
+        ``file_path`` rather than being dropped, so the caller can report them.
+        """
+
+        def operation(connection: sqlite3.Connection) -> list[dict[str, Any]]:
+            rows = connection.execute(
+                "SELECT pt.position, pt.track_name, pt.artist_name, "
+                "pt.duration, t.file_path, t.relative_path, t.root_id "
+                "FROM library_playlist_tracks pt "
+                "LEFT JOIN local_tracks t ON t.id = pt.local_track_id "
+                "WHERE pt.playlist_id = ? ORDER BY pt.position",
+                (playlist_id,),
+            ).fetchall()
+            return [dict(row) for row in rows]
+
+        return await self._read(operation)
+
     async def get_target_playlist_track(
         self, playlist_id: str, track_id: str
     ) -> dict[str, Any] | None:

--- a/backend/services/navidrome_playlist_export_service.py
+++ b/backend/services/navidrome_playlist_export_service.py
@@ -1,0 +1,339 @@
+"""Export DroppedNeedle playlists as .m3u8 files for Navidrome to import.
+
+Navidrome has no playlist write API but imports playlist files it finds while
+scanning (``ND_PLAYLISTSPATH``, enabled by ``ND_AUTOIMPORTPLAYLISTS``). One-way:
+Navidrome's own playlists are never read back.
+
+The target directory is not exclusively ours, so ownership is proven by a marker
+inside each file, a failed export keeps its previous file, and entries are
+relative. No state is kept between runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import unicodedata
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path, PurePath
+
+logger = logging.getLogger(__name__)
+
+PLAYLIST_SUFFIX = ".m3u8"
+OWNER_MARKER = "#DROPPEDNEEDLE-PLAYLIST-ID:"
+_MARKER_SCAN_BYTES = 512
+
+# Applied on every host, not just Windows: an exported directory is often a bind
+# mount shared with one.
+_WINDOWS_RESERVED = {
+    "CON", "PRN", "AUX", "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+}
+_UNSAFE_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+# M3U is line-oriented and has no escaping, so a newline in free text would
+# inject a directive.
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+_MAX_STEM = 120
+
+
+@dataclass
+class PlaylistSyncResult:
+    success: bool = False
+    message: str = ""
+    written: int = 0
+    unchanged: int = 0
+    removed: int = 0
+    skipped_empty: int = 0
+    skipped_not_ours: int = 0
+    removal_failures: int = 0
+    tracks_missing_files: int = 0
+    tracks_unrepresentable: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+def _one_line(value: str | None) -> str:
+    return _CONTROL_CHARS.sub(" ", (value or "")).strip()
+
+
+def safe_playlist_filename(name: str, playlist_id: str) -> str:
+    """A portable filename. The id suffix carries uniqueness; names collide."""
+    stem = unicodedata.normalize("NFC", name or "").strip()
+    stem = _UNSAFE_CHARS.sub("_", stem)
+    stem = stem.strip(" .")
+    if stem.upper().split(".")[0] in _WINDOWS_RESERVED:
+        stem = f"_{stem}"
+    if len(stem) > _MAX_STEM:
+        stem = stem[:_MAX_STEM].rstrip(" .")
+    if not stem:
+        stem = "playlist"
+    return f"{stem} [{playlist_id[:8]}]{PLAYLIST_SUFFIX}"
+
+
+def owned_playlist_id(path: Path) -> str | None:
+    """The playlist id this file declares, or None if it is not ours."""
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            head = handle.read(_MARKER_SCAN_BYTES)
+    except OSError:
+        return None
+    for line in head.splitlines():
+        if line.startswith(OWNER_MARKER):
+            return line[len(OWNER_MARKER):].strip() or None
+    return None
+
+
+def _entry_path(track_path: str, playlist_dir: Path) -> str | None:
+    """Track path relative to the playlist file, or None on a different drive.
+
+    Not substituted with an absolute path: that resolves only if Navidrome
+    mounts the library identically.
+    """
+    try:
+        relative = os.path.relpath(track_path, start=playlist_dir)
+    except ValueError:
+        return None
+    return PurePath(relative).as_posix()
+
+
+def render_playlist(
+    name: str, playlist_id: str, entries: list[dict], playlist_dir: Path
+) -> tuple[str, int, int]:
+    """Render extended M3U. Returns (text, entries with no file, unrepresentable)."""
+    lines = ["#EXTM3U", f"{OWNER_MARKER}{playlist_id}", f"#PLAYLIST:{_one_line(name)}"]
+    missing = 0
+    unrepresentable = 0
+    for entry in entries:
+        track_path = entry.get("file_path")
+        if not track_path:
+            missing += 1
+            continue
+        rendered = _entry_path(track_path, playlist_dir)
+        if rendered is None or _CONTROL_CHARS.search(rendered):
+            unrepresentable += 1
+            continue
+        duration = entry.get("duration")
+        seconds = int(duration) if isinstance(duration, (int, float)) else -1
+        artist = _one_line(entry.get("artist_name"))
+        title = _one_line(entry.get("track_name"))
+        label = f"{artist} - {title}" if artist else title
+        lines.append(f"#EXTINF:{seconds},{label}")
+        lines.append(rendered)
+    return "\n".join(lines) + "\n", missing, unrepresentable
+
+
+class NavidromePlaylistExportService:
+    def __init__(self, store) -> None:  # noqa: ANN001 - NativeLibraryStore
+        self._store = store
+        # Sync Now and the periodic task must not interleave.
+        self._lock = asyncio.Lock()
+
+    async def sync(
+        self,
+        *,
+        target_dir: str,
+        scope: str = "public",
+        remove_deleted: bool = True,
+    ) -> PlaylistSyncResult:
+        async with self._lock:
+            return await self._sync_locked(
+                target_dir=target_dir, scope=scope, remove_deleted=remove_deleted
+            )
+
+    async def _sync_locked(
+        self, *, target_dir: str, scope: str, remove_deleted: bool
+    ) -> PlaylistSyncResult:
+        """Render every qualifying playlist and write the ones that changed."""
+        result = PlaylistSyncResult()
+
+        if not target_dir:
+            result.message = "Set a playlist folder before syncing."
+            return result
+
+        directory = Path(target_dir).expanduser()
+        if not directory.is_absolute():
+            # A relative path resolves against the working directory.
+            result.message = "The playlist folder must be a full path starting with /."
+            return result
+
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+        except OSError as error:
+            result.message = f"Cannot create the playlist folder: {error}"
+            return result
+        if not os.access(directory, os.W_OK):
+            result.message = (
+                "DroppedNeedle cannot write to the playlist folder. Check it is "
+                "mounted into this container and writable by it."
+            )
+            return result
+
+        try:
+            playlists = await self._store.list_target_playlists()
+        except Exception as error:  # noqa: BLE001 - reported, not raised at the UI
+            logger.exception("Playlist export could not read playlists")
+            result.message = f"Could not read playlists: {error}"
+            return result
+
+        if scope == "public":
+            playlists = [p for p in playlists if p.get("is_public")]
+
+        written: dict[str, str] = {}
+        failed: set[str] = set()
+
+        for playlist in playlists:
+            playlist_id = str(playlist.get("id") or "")
+            if not playlist_id:
+                continue
+            name = str(playlist.get("name") or "Playlist")
+
+            try:
+                entries = await self._store.list_target_playlist_export_rows(
+                    playlist_id
+                )
+            except Exception as error:  # noqa: BLE001 - one playlist cannot stop the rest
+                logger.exception("Playlist export failed to read %s", playlist_id)
+                result.errors.append(f"{name}: {error}")
+                failed.add(playlist_id)
+                continue
+
+            text, missing, unrepresentable = render_playlist(
+                name, playlist_id, entries, directory
+            )
+            result.tracks_missing_files += missing
+            result.tracks_unrepresentable += unrepresentable
+            if missing + unrepresentable == len(entries):
+                # An empty playlist reads as data loss, not as a failed export.
+                result.skipped_empty += 1
+                failed.add(playlist_id)
+                continue
+
+            filename = safe_playlist_filename(name, playlist_id)
+            destination = directory / filename
+            if destination.exists() and owned_playlist_id(destination) != playlist_id:
+                logger.warning(
+                    "Playlist export skipped %s: the file is not DroppedNeedle's",
+                    filename,
+                )
+                result.skipped_not_ours += 1
+                failed.add(playlist_id)
+                continue
+
+            if self._matches_on_disk(destination, text):
+                result.unchanged += 1
+                written[playlist_id] = filename
+                continue
+
+            try:
+                self._write_atomic(destination, text)
+            except OSError as error:
+                logger.warning(
+                    "Playlist export could not write %s: %s", filename, error
+                )
+                result.errors.append(f"{name}: {error}")
+                failed.add(playlist_id)
+                continue
+            written[playlist_id] = filename
+
+        if remove_deleted:
+            result.removed, result.removal_failures = self._remove_stale(
+                directory, written, failed
+            )
+
+        result.written = len(written) - result.unchanged
+        # Not a success while a removal is outstanding: the playlist is still
+        # readable in Navidrome.
+        result.success = not result.errors and not result.removal_failures
+        result.message = self._summarise(result)
+        return result
+
+    @staticmethod
+    def _matches_on_disk(path: Path, text: str) -> bool:
+        """Whether the file already holds exactly this text.
+
+        Skipping the write avoids churning mtimes and provoking a rescan.
+        """
+        try:
+            return path.read_text(encoding="utf-8") == text
+        except (OSError, UnicodeDecodeError):
+            return False
+
+    @staticmethod
+    def _summarise(result: PlaylistSyncResult) -> str:
+        parts = [f"{result.written} written"]
+        if result.unchanged:
+            parts.append(f"{result.unchanged} already current")
+        if result.removed:
+            parts.append(f"{result.removed} removed")
+        if result.skipped_empty:
+            parts.append(f"{result.skipped_empty} skipped, no tracks in your library")
+        if result.skipped_not_ours:
+            parts.append(
+                f"{result.skipped_not_ours} skipped, a file of that name was not "
+                "created by DroppedNeedle"
+            )
+        if result.tracks_missing_files:
+            parts.append(f"{result.tracks_missing_files} tracks not in your library")
+        if result.tracks_unrepresentable:
+            parts.append(
+                f"{result.tracks_unrepresentable} tracks on a different drive to the "
+                "playlist folder"
+            )
+        if result.removal_failures:
+            parts.append(
+                f"{result.removal_failures} could not be removed, will retry next sync"
+            )
+        if result.errors:
+            parts.append(f"{len(result.errors)} failed")
+        return ", ".join(parts) + "."
+
+    @staticmethod
+    def _write_atomic(path: Path, text: str) -> None:
+        """Write to a unique temporary file, then replace.
+
+        Navidrome may scan mid-write. The random suffix keeps concurrent
+        writers off each other's temporary file.
+        """
+        temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex[:8]}.tmp")
+        try:
+            temporary.write_text(text, encoding="utf-8", newline="\n")
+            os.replace(temporary, path)
+        except OSError:
+            temporary.unlink(missing_ok=True)
+            raise
+
+    def _remove_stale(
+        self, directory: Path, written: dict[str, str], failed: set[str]
+    ) -> tuple[int, int]:
+        """Delete our exports that this run no longer maintains.
+
+        Candidates come from the directory, not a stored index: each file names
+        its playlist, so a failed deletion simply retries next run.
+
+        Returns the count removed and the count that could not be.
+        """
+        removed = 0
+        failures = 0
+        current_names = set(written.values())
+        for candidate in sorted(directory.glob(f"*{PLAYLIST_SUFFIX}")):
+            if candidate.name in current_names or not candidate.is_file():
+                continue
+            playlist_id = owned_playlist_id(candidate)
+            if playlist_id is None:
+                # Not ours: a hand-made playlist, or another tool's.
+                continue
+            if playlist_id in failed:
+                # Its export failed this run, so it is not confirmed gone.
+                continue
+            try:
+                candidate.unlink()
+                removed += 1
+            except OSError as error:
+                logger.warning(
+                    "Playlist export could not remove %s: %s", candidate.name, error
+                )
+                failures += 1
+        return removed, failures

--- a/backend/services/preferences_service.py
+++ b/backend/services/preferences_service.py
@@ -879,6 +879,12 @@ class PreferencesService:
             username=nd_data.get("username", ""),
             password=NAVIDROME_PASSWORD_MASK if password else "",
             enabled=nd_data.get("enabled", False),
+            playlist_sync_enabled=nd_data.get("playlist_sync_enabled", False),
+            playlist_sync_path=nd_data.get("playlist_sync_path", ""),
+            playlist_sync_scope=nd_data.get("playlist_sync_scope", "public"),
+            playlist_sync_remove_deleted=nd_data.get(
+                "playlist_sync_remove_deleted", True
+            ),
         )
 
     def get_navidrome_connection_raw(self) -> NavidromeConnectionSettings:
@@ -892,6 +898,12 @@ class PreferencesService:
             username=nd_data.get("username", ""),
             password=password,
             enabled=nd_data.get("enabled", False),
+            playlist_sync_enabled=nd_data.get("playlist_sync_enabled", False),
+            playlist_sync_path=nd_data.get("playlist_sync_path", ""),
+            playlist_sync_scope=nd_data.get("playlist_sync_scope", "public"),
+            playlist_sync_remove_deleted=nd_data.get(
+                "playlist_sync_remove_deleted", True
+            ),
         )
 
     def save_navidrome_connection(self, settings: NavidromeConnectionSettings) -> None:
@@ -910,6 +922,10 @@ class PreferencesService:
                 "username": settings.username,
                 "password": password,
                 "enabled": settings.enabled,
+                "playlist_sync_enabled": settings.playlist_sync_enabled,
+                "playlist_sync_path": settings.playlist_sync_path,
+                "playlist_sync_scope": settings.playlist_sync_scope,
+                "playlist_sync_remove_deleted": settings.playlist_sync_remove_deleted,
             }
             self._save_config(config)
         except Exception as e:  # noqa: BLE001

--- a/backend/target_application.py
+++ b/backend/target_application.py
@@ -197,6 +197,7 @@ from core.task_registry import TaskRegistry
 from core.tasks import (
     start_cache_cleanup_task,
     start_disk_cache_cleanup_task,
+    start_navidrome_playlist_export_task,
     start_memory_maintenance_task,
 )
 from infrastructure.http.compression import CompressibleGZipMiddleware
@@ -598,6 +599,7 @@ async def production_target_lifespan(app: FastAPI):
             interval=advanced.disk_cache_cleanup_interval,
             cover_disk_cache=get_target_consumer_composition().covers.disk_cache,
         )
+        start_navidrome_playlist_export_task()
 
         def root_paths() -> dict[str, Path]:
             return {

--- a/backend/tests/security/test_single_audio_writer_boundary.py
+++ b/backend/tests/security/test_single_audio_writer_boundary.py
@@ -57,6 +57,7 @@ _FILESYSTEM_ALLOWLIST = {
     "services/native/edition_conversion_service.py",  # edition-conversion bundle staging
     "services/native/file_processor.py",  # slskd download staging before the import lane
     "services/playlist_service.py",  # user-initiated playlist export (writes outside the library)
+    "services/navidrome_playlist_export_service.py",  # .m3u8 export; writes/removes only marker-owned playlist files, never audio
     "services/local_files_service.py",  # album zip export via NamedTemporaryFile outside the library
     "services/cache_service.py",  # disposable cache-dir maintenance
     "services/preferences_service.py",  # config.json persistence

--- a/backend/tests/services/test_navidrome_playlist_export_service.py
+++ b/backend/tests/services/test_navidrome_playlist_export_service.py
@@ -1,0 +1,713 @@
+"""NavidromePlaylistExportService tests.
+
+The export writes into a directory that is not exclusively ours - usually
+Navidrome's music folder - so these concentrate on the properties that make
+that safe: relative entries, marker-proven ownership, and a failed export never
+becoming a deletion.
+"""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.navidrome_playlist_export_service import (
+    OWNER_MARKER,
+    NavidromePlaylistExportService,
+    owned_playlist_id,
+    render_playlist,
+    safe_playlist_filename,
+)
+
+
+def _playlist(pid: str, name: str, *, public: bool = True) -> dict:
+    return {"id": pid, "name": name, "is_public": 1 if public else 0}
+
+
+def _entry(position: int, path: str | None, *, title: str = "Track") -> dict:
+    return {
+        "position": position,
+        "track_name": title,
+        "artist_name": "Artist",
+        "duration": 180,
+        "file_path": path,
+        "relative_path": path,
+        "root_id": "root-1",
+    }
+
+
+def _service(playlists: list[dict], entries: dict[str, list[dict]]):
+    store = AsyncMock()
+    store.list_target_playlists = AsyncMock(return_value=playlists)
+
+    async def rows(playlist_id: str):
+        return entries.get(playlist_id, [])
+
+    store.list_target_playlist_export_rows = AsyncMock(side_effect=rows)
+    return NavidromePlaylistExportService(store)
+
+
+# Filename safety
+
+
+def test_filename_is_unique_per_playlist_when_names_collide():
+    first = safe_playlist_filename("Favourites", "aaaaaaaa-1111")
+    second = safe_playlist_filename("Favourites", "bbbbbbbb-2222")
+    assert first != second
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["CON", "back/slash", "colon:name", "trailing.", "  ", ""],
+)
+def test_filename_is_portable_for_hostile_names(name):
+    result = safe_playlist_filename(name, "abcdefgh-1234")
+    stem = result.rsplit(".", 1)[0]
+    assert not set(result) & set('<>:"/\\|?*')
+    assert stem.upper().split(" ")[0] not in {"CON", "PRN", "AUX", "NUL"}
+    assert result.endswith(".m3u8")
+    assert result.strip() == result
+
+
+def test_filename_is_length_bounded():
+    result = safe_playlist_filename("x" * 500, "abcdefgh-1234")
+    assert len(result) < 160
+
+
+# Entry rendering
+
+
+def test_entries_are_relative_to_the_playlist_directory(tmp_path: Path):
+    playlist_dir = tmp_path / "music" / "playlists"
+    text, missing, _unrepresentable = render_playlist(
+        "Mix",
+        "p1",
+        [_entry(1, str(tmp_path / "music" / "A" / "Artist" / "Album" / "01.flac"))],
+        playlist_dir,
+    )
+    assert missing == 0
+    assert "../A/Artist/Album/01.flac" in text
+    # An absolute path here would break the moment Navidrome mounts the library
+    # somewhere other than DroppedNeedle does.
+    assert str(tmp_path) not in text
+
+
+def test_entries_use_forward_slashes(tmp_path: Path):
+    text, _missing, _unrepresentable = render_playlist(
+        "Mix", "p1", [_entry(1, str(tmp_path / "A" / "B" / "01.flac"))], tmp_path
+    )
+    path_line = [line for line in text.splitlines() if not line.startswith("#")][0]
+    assert "\\" not in path_line
+
+
+def test_extinf_carries_duration_and_label(tmp_path: Path):
+    text, _missing, _unrepresentable = render_playlist(
+        "Mix", "p1", [_entry(1, str(tmp_path / "01.flac"), title="Song")], tmp_path
+    )
+    assert "#EXTM3U" in text
+    assert "#PLAYLIST:Mix" in text
+    assert "#EXTINF:180,Artist - Song" in text
+
+
+def test_entries_without_a_local_file_are_counted_not_dropped_silently(tmp_path: Path):
+    text, missing, _unrepresentable = render_playlist(
+        "Mix",
+        "p1",
+        [_entry(1, str(tmp_path / "01.flac")), _entry(2, None)],
+        tmp_path,
+    )
+    assert missing == 1
+    assert text.count("#EXTINF") == 1
+
+
+# Sync behaviour
+
+
+@pytest.mark.asyncio
+async def test_sync_writes_one_file_per_playlist(tmp_path: Path):
+    service = _service(
+        [_playlist("p1", "Alpha"), _playlist("p2", "Beta")],
+        {
+            "p1": [_entry(1, str(tmp_path / "a.flac"))],
+            "p2": [_entry(1, str(tmp_path / "b.flac"))],
+        },
+    )
+
+    result = await service.sync(target_dir=str(tmp_path))
+
+    assert result.success
+    assert result.written == 2
+    assert len(list(tmp_path.glob("*.m3u8"))) == 2
+
+
+@pytest.mark.asyncio
+async def test_public_scope_excludes_private_playlists(tmp_path: Path):
+    service = _service(
+        [_playlist("p1", "Shared"), _playlist("p2", "Private", public=False)],
+        {
+            "p1": [_entry(1, str(tmp_path / "a.flac"))],
+            "p2": [_entry(1, str(tmp_path / "b.flac"))],
+        },
+    )
+
+    result = await service.sync(target_dir=str(tmp_path), scope="public")
+
+    assert result.written == 1
+    assert not list(tmp_path.glob("Private*"))
+
+
+@pytest.mark.asyncio
+async def test_all_scope_includes_private_playlists(tmp_path: Path):
+    service = _service(
+        [_playlist("p1", "Shared"), _playlist("p2", "Private", public=False)],
+        {
+            "p1": [_entry(1, str(tmp_path / "a.flac"))],
+            "p2": [_entry(1, str(tmp_path / "b.flac"))],
+        },
+    )
+
+    result = await service.sync(target_dir=str(tmp_path), scope="all")
+
+    assert result.written == 2
+
+
+@pytest.mark.asyncio
+async def test_playlist_with_no_local_tracks_is_skipped_not_written_empty(
+    tmp_path: Path,
+):
+    service = _service([_playlist("p1", "Streaming only")], {"p1": [_entry(1, None)]})
+
+    result = await service.sync(target_dir=str(tmp_path))
+
+    assert result.skipped_empty == 1
+    assert result.written == 0
+    assert not list(tmp_path.glob("*.m3u8"))
+
+
+@pytest.mark.asyncio
+async def test_removal_deletes_only_files_this_service_wrote(tmp_path: Path):
+    foreign = tmp_path / "my own playlist.m3u8"
+    foreign.write_text("#EXTM3U\n", encoding="utf-8")
+
+    service = _service([_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]})
+    await service.sync(target_dir=str(tmp_path))
+
+    # Alpha disappears from DroppedNeedle; the hand-made file must survive.
+    gone = _service([], {})
+    result = await gone.sync(target_dir=str(tmp_path), remove_deleted=True)
+
+    assert result.removed == 1
+    assert foreign.exists()
+    assert not list(tmp_path.glob("Alpha*"))
+
+
+@pytest.mark.asyncio
+async def test_never_remove_leaves_orphaned_exports_in_place(tmp_path: Path):
+    service = _service([_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]})
+    await service.sync(target_dir=str(tmp_path))
+
+    gone = _service([], {})
+    result = await gone.sync(target_dir=str(tmp_path), remove_deleted=False)
+
+    assert result.removed == 0
+    assert list(tmp_path.glob("Alpha*"))
+
+
+
+@pytest.mark.asyncio
+async def test_missing_directory_is_created(tmp_path: Path):
+    target = tmp_path / "not" / "there" / "yet"
+    service = _service([_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]})
+
+    result = await service.sync(target_dir=str(target))
+
+    assert result.success
+    assert target.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_empty_path_fails_with_a_message_not_an_exception(tmp_path: Path):
+    service = _service([], {})
+
+    result = await service.sync(target_dir="")
+
+    assert not result.success
+    assert "Set a playlist folder" in result.message
+
+
+@pytest.mark.asyncio
+async def test_unicode_names_survive_the_round_trip(tmp_path: Path):
+    service = _service(
+        [_playlist("p1", "RÜFÜS DU SOL — 소리")],
+        {"p1": [_entry(1, str(tmp_path / "Ain’t.flac"), title="Ain’t Gonna Die")]},
+    )
+
+    result = await service.sync(target_dir=str(tmp_path))
+
+    assert result.written == 1
+    written = next(tmp_path.glob("*.m3u8"))
+    assert "Ain’t Gonna Die" in written.read_text(encoding="utf-8")
+
+
+# Failure handling and ownership
+
+
+@pytest.mark.asyncio
+async def test_read_failure_does_not_delete_the_prior_export(tmp_path: Path):
+    """A transient error must not be read as "the playlist is gone"."""
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    await service.sync(target_dir=str(tmp_path))
+    exported = next(tmp_path.glob("Alpha*"))
+
+    broken = _service([_playlist("p1", "Alpha")], {})
+    broken._store.list_target_playlist_export_rows = AsyncMock(
+        side_effect=RuntimeError("database is locked")
+    )
+    result = await broken.sync(target_dir=str(tmp_path), remove_deleted=True)
+
+    assert not result.success
+    assert result.removed == 0
+    assert exported.exists()
+    # Ownership lives in the file, so the next run still recognises it.
+    assert owned_playlist_id(exported) == "p1"
+
+
+@pytest.mark.asyncio
+async def test_write_failure_does_not_delete_the_prior_export(tmp_path: Path):
+    """The same guarantee when the write fails rather than the read."""
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    await service.sync(target_dir=str(tmp_path))
+    exported = next(tmp_path.glob("Alpha*"))
+    original = exported.read_text(encoding="utf-8")
+
+    # The track title must differ, or the rendered text matches what is already
+    # on disk, no write is attempted and this asserts nothing.
+    failing = _service(
+        [_playlist("p1", "Alpha")],
+        {"p1": [_entry(1, str(tmp_path / "a.flac"), title="Renamed")]},
+    )
+    attempted = False
+
+    def explode(path, text):
+        nonlocal attempted
+        attempted = True
+        raise OSError("No space left on device")
+
+    failing._write_atomic = explode
+    result = await failing.sync(target_dir=str(tmp_path), remove_deleted=True)
+
+    assert attempted
+    assert not result.success
+    assert result.removed == 0
+    assert exported.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.asyncio
+async def test_a_colliding_hand_made_file_is_never_overwritten(tmp_path: Path):
+    """The manifest is an index, not proof that we wrote a file."""
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    filename = safe_playlist_filename("Alpha", "p1")
+    handmade = tmp_path / filename
+    handmade.write_text("#EXTM3U\n/somewhere/else.flac\n", encoding="utf-8")
+
+    result = await service.sync(target_dir=str(tmp_path))
+
+    assert result.skipped_not_ours == 1
+    assert result.written == 0
+    assert handmade.read_text(encoding="utf-8") == "#EXTM3U\n/somewhere/else.flac\n"
+
+
+@pytest.mark.asyncio
+async def test_a_file_replaced_by_hand_after_export_is_not_deleted(tmp_path: Path):
+    """Ownership is re-checked at deletion, not trusted from the manifest."""
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    await service.sync(target_dir=str(tmp_path))
+    exported = next(tmp_path.glob("Alpha*"))
+    exported.write_text("#EXTM3U\n# mine now\n", encoding="utf-8")
+
+    gone = _service([], {})
+    result = await gone.sync(target_dir=str(tmp_path), remove_deleted=True)
+
+    assert result.removed == 0
+    assert exported.exists()
+
+
+@pytest.mark.asyncio
+async def test_exported_files_carry_the_ownership_marker(tmp_path: Path):
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+
+    await service.sync(target_dir=str(tmp_path))
+
+    exported = next(tmp_path.glob("Alpha*"))
+    assert f"{OWNER_MARKER}p1" in exported.read_text(encoding="utf-8")
+    assert owned_playlist_id(exported) == "p1"
+
+
+def test_owned_playlist_id_rejects_a_foreign_file(tmp_path: Path):
+    foreign = tmp_path / "theirs.m3u8"
+    foreign.write_text("#EXTM3U\n#EXTINF:1,A\n/a.flac\n", encoding="utf-8")
+    assert owned_playlist_id(foreign) is None
+
+
+# Input handling
+
+
+@pytest.mark.asyncio
+async def test_relative_target_directory_is_refused(tmp_path: Path):
+    service = _service([], {})
+    result = await service.sync(target_dir="playlists")
+    assert not result.success
+    assert "full path" in result.message
+
+
+def test_control_characters_cannot_inject_m3u_lines(tmp_path: Path):
+    """Assert the exact lines: a count check alone can pass on a layout where
+    the injected text landed somewhere unexpected."""
+    text, _missing, _unrepresentable = render_playlist(
+        "Evil\n#EXTINF:1,injected",
+        "p1",
+        [_entry(1, str(tmp_path / "a.flac"), title="Title\n#EXTINF:9,other")],
+        tmp_path,
+    )
+
+    assert text.splitlines() == [
+        "#EXTM3U",
+        f"{OWNER_MARKER}p1",
+        "#PLAYLIST:Evil #EXTINF:1,injected",
+        "#EXTINF:180,Artist - Title #EXTINF:9,other",
+        "a.flac",
+    ]
+    # The injected text survives only as inert content inside the expected
+    # lines, never as a directive of its own.
+    assert sum(line.startswith("#EXTINF:") for line in text.splitlines()) == 1
+    assert "\r" not in text
+
+
+def test_temporary_files_are_unique_per_write(tmp_path: Path):
+    service = NavidromePlaylistExportService(AsyncMock())
+    names = set()
+    original = Path.write_text
+
+    def capture(self, *args, **kwargs):
+        names.add(self.name)
+        return original(self, *args, **kwargs)
+
+    Path.write_text = capture
+    try:
+        service._write_atomic(tmp_path / "a.m3u8", "#EXTM3U\n")
+        service._write_atomic(tmp_path / "a.m3u8", "#EXTM3U\n")
+    finally:
+        Path.write_text = original
+
+    assert len(names) == 2
+
+
+@pytest.mark.asyncio
+async def test_unchanged_playlist_is_not_rewritten(tmp_path: Path):
+    """No mtime churn on a steady library, so Navidrome does not rescan."""
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    await service.sync(target_dir=str(tmp_path))
+    exported = next(tmp_path.glob("Alpha*"))
+    before = exported.stat().st_mtime_ns
+
+    result = await service.sync(target_dir=str(tmp_path))
+
+    assert result.unchanged == 1
+    assert result.written == 0
+    assert exported.stat().st_mtime_ns == before
+
+
+@pytest.mark.asyncio
+async def test_a_changed_track_path_is_rewritten(tmp_path: Path):
+    """A library rename moves a file without touching the playlist's id,
+    timestamp or track count."""
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "old.flac"))]}
+    )
+    await service.sync(target_dir=str(tmp_path))
+
+    moved = _service(
+        [_playlist("p1", "Alpha")],
+        {"p1": [_entry(1, str(tmp_path / "renamed" / "new.flac"))]},
+    )
+    result = await moved.sync(target_dir=str(tmp_path))
+
+    assert result.written == 1
+    exported = next(tmp_path.glob("Alpha*"))
+    assert "renamed/new.flac" in exported.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_a_changed_target_directory_is_populated(tmp_path: Path):
+    """Changing the folder must export there immediately."""
+    first = tmp_path / "one"
+    second = tmp_path / "two"
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+
+    await service.sync(target_dir=str(first))
+    result = await service.sync(target_dir=str(second))
+
+    assert result.written == 1
+    assert list(second.glob("Alpha*"))
+
+
+@pytest.mark.asyncio
+async def test_a_previously_skipped_playlist_is_retried(tmp_path: Path):
+    """A skip must not be recorded as done."""
+    empty = _service([_playlist("p1", "Alpha")], {"p1": [_entry(1, None)]})
+    first = await empty.sync(target_dir=str(tmp_path))
+    assert first.skipped_empty == 1
+
+    available = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    result = await available.sync(target_dir=str(tmp_path))
+
+    assert result.written == 1
+
+
+@pytest.mark.asyncio
+async def test_renaming_a_playlist_removes_its_previous_file(tmp_path: Path):
+    """The filename follows the title, so a rename orphans the old file."""
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    await service.sync(target_dir=str(tmp_path))
+    assert list(tmp_path.glob("Alpha*"))
+
+    renamed = _service(
+        [_playlist("p1", "Beta")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    result = await renamed.sync(target_dir=str(tmp_path), remove_deleted=True)
+
+    assert result.removed == 1
+    assert list(tmp_path.glob("Beta*"))
+    assert not list(tmp_path.glob("Alpha*"))
+
+
+@pytest.mark.asyncio
+async def test_renaming_leaves_the_old_file_when_removal_is_off(tmp_path: Path):
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    await service.sync(target_dir=str(tmp_path))
+
+    renamed = _service(
+        [_playlist("p1", "Beta")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    result = await renamed.sync(target_dir=str(tmp_path), remove_deleted=False)
+
+    assert result.removed == 0
+    assert list(tmp_path.glob("Alpha*"))
+    assert list(tmp_path.glob("Beta*"))
+
+
+
+@pytest.mark.asyncio
+async def test_concurrent_syncs_are_serialised(tmp_path: Path):
+    """Sync Now and the periodic task share one service instance."""
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    overlaps = 0
+    active = 0
+    original = service._store.list_target_playlists
+
+    async def watched():
+        nonlocal overlaps, active
+        active += 1
+        if active > 1:
+            overlaps += 1
+        await asyncio.sleep(0)
+        active -= 1
+        return await original()
+
+    service._store.list_target_playlists = watched
+
+    await asyncio.gather(
+        service.sync(target_dir=str(tmp_path)),
+        service.sync(target_dir=str(tmp_path)),
+    )
+
+    assert overlaps == 0
+
+
+@pytest.mark.asyncio
+async def test_a_failed_removal_is_retried_on_the_next_sync(tmp_path: Path):
+    """A read-only mount must not leave a deleted playlist exposed forever."""
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    await service.sync(target_dir=str(tmp_path))
+    exported = next(tmp_path.glob("Alpha*"))
+
+    gone = _service([], {})
+    real_unlink = Path.unlink
+
+    def refuse(self, *args, **kwargs):
+        if self.name == exported.name:
+            raise OSError("Read-only file system")
+        return real_unlink(self, *args, **kwargs)
+
+    Path.unlink = refuse
+    try:
+        first = await gone.sync(target_dir=str(tmp_path), remove_deleted=True)
+    finally:
+        Path.unlink = real_unlink
+
+    assert first.removed == 0
+    assert first.removal_failures == 1
+    assert exported.exists()
+
+    second = await gone.sync(target_dir=str(tmp_path), remove_deleted=True)
+
+    assert second.removed == 1
+    assert not exported.exists()
+
+
+@pytest.mark.asyncio
+async def test_a_failed_rename_removal_is_retried_on_the_next_sync(tmp_path: Path):
+    """The pending entry carries its own filename, so a rename retries too."""
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    await service.sync(target_dir=str(tmp_path))
+    old = next(tmp_path.glob("Alpha*"))
+
+    renamed = _service(
+        [_playlist("p1", "Beta")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    real_unlink = Path.unlink
+
+    def refuse(self, *args, **kwargs):
+        if self.name == old.name:
+            raise OSError("Device or resource busy")
+        return real_unlink(self, *args, **kwargs)
+
+    Path.unlink = refuse
+    try:
+        first = await renamed.sync(target_dir=str(tmp_path), remove_deleted=True)
+    finally:
+        Path.unlink = real_unlink
+
+    assert first.removal_failures == 1
+    assert old.exists()
+    assert list(tmp_path.glob("Beta*"))
+
+    second = await renamed.sync(target_dir=str(tmp_path), remove_deleted=True)
+
+    assert second.removed == 1
+    assert not old.exists()
+    assert list(tmp_path.glob("Beta*"))
+
+
+
+@pytest.mark.asyncio
+async def test_a_deferred_removal_reports_as_a_failure(tmp_path: Path):
+    """The count must reach the caller: a deferred removal means a playlist is
+    still readable in Navidrome that should not be."""
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    await service.sync(target_dir=str(tmp_path))
+    exported = next(tmp_path.glob("Alpha*"))
+
+    gone = _service([], {})
+    real_unlink = Path.unlink
+
+    def refuse(self, *args, **kwargs):
+        if self.name == exported.name:
+            raise OSError("Read-only file system")
+        return real_unlink(self, *args, **kwargs)
+
+    Path.unlink = refuse
+    try:
+        result = await gone.sync(target_dir=str(tmp_path), remove_deleted=True)
+    finally:
+        Path.unlink = real_unlink
+
+    assert result.removal_failures == 1
+    assert result.success is False
+    assert "will retry next sync" in result.message
+
+
+@pytest.mark.asyncio
+async def test_ownership_survives_a_corrupt_leftover_index(tmp_path: Path):
+    """A stale or corrupt index file from any source must not affect cleanup."""
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    await service.sync(target_dir=str(tmp_path))
+    (tmp_path / ".droppedneedle-playlists.json").write_text(
+        "{ this is not json", encoding="utf-8"
+    )
+
+    gone = _service([], {})
+    result = await gone.sync(target_dir=str(tmp_path), remove_deleted=True)
+
+    assert result.removed == 1
+    assert not list(tmp_path.glob("Alpha*"))
+
+
+@pytest.mark.asyncio
+async def test_cleanup_works_with_no_prior_state_at_all(tmp_path: Path):
+    """A file written by an earlier install, with nothing else on disk, is still
+    recognised as ours and cleaned up when its playlist goes."""
+    orphan = tmp_path / safe_playlist_filename("Alpha", "p1")
+    orphan.write_text(f"#EXTM3U\n{OWNER_MARKER}p1\n#PLAYLIST:Alpha\na.flac\n", encoding="utf-8")
+
+    service = _service([], {})
+    result = await service.sync(target_dir=str(tmp_path), remove_deleted=True)
+
+    assert result.removed == 1
+    assert not orphan.exists()
+
+
+@pytest.mark.asyncio
+async def test_a_read_only_directory_reports_rather_than_silently_skipping(
+    tmp_path: Path,
+):
+    """A removal that cannot happen must fail the run, every run, until it can."""
+    service = _service(
+        [_playlist("p1", "Alpha")], {"p1": [_entry(1, str(tmp_path / "a.flac"))]}
+    )
+    await service.sync(target_dir=str(tmp_path))
+    exported = next(tmp_path.glob("Alpha*"))
+
+    gone = _service([], {})
+    real_unlink = Path.unlink
+
+    def refuse(self, *args, **kwargs):
+        if self.name == exported.name:
+            raise OSError("Read-only file system")
+        return real_unlink(self, *args, **kwargs)
+
+    Path.unlink = refuse
+    try:
+        first = await gone.sync(target_dir=str(tmp_path), remove_deleted=True)
+        second = await gone.sync(target_dir=str(tmp_path), remove_deleted=True)
+    finally:
+        Path.unlink = real_unlink
+
+    # Reported both times: nothing was remembered that could mask the second.
+    assert first.removal_failures == 1 and first.success is False
+    assert second.removal_failures == 1 and second.success is False
+
+    third = await gone.sync(target_dir=str(tmp_path), remove_deleted=True)
+    assert third.removed == 1
+    assert third.success is True

--- a/frontend/src/lib/components/settings/SettingsNavidrome.svelte
+++ b/frontend/src/lib/components/settings/SettingsNavidrome.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { createSettingsForm } from '$lib/utils/settingsForm.svelte';
 	import { onDestroy } from 'svelte';
-	import type { NavidromeConnectionSettings } from '$lib/types';
+	import { api, ApiError } from '$lib/api/client';
+	import type { NavidromeConnectionSettings, NavidromePlaylistSyncResult } from '$lib/types';
 
 	type NavidromeTestResult = { valid: boolean; message: string };
 	type NavidromeSettingsForm = ReturnType<
@@ -19,9 +20,42 @@
 	}) as NavidromeSettingsForm;
 
 	let showPassword = $state(false);
+	let syncing = $state(false);
+	let syncResult = $state<NavidromePlaylistSyncResult | null>(null);
 
 	export async function load() {
 		await form.load();
+	}
+
+	async function syncPlaylists() {
+		syncing = true;
+		syncResult = null;
+		try {
+			// The endpoint reads saved settings, so save first or an edited
+			// path or scope is ignored.
+			await form.save();
+			syncResult = await api.post<NavidromePlaylistSyncResult>(
+				'/api/v1/settings/navidrome/playlist-sync'
+			);
+		} catch (error) {
+			syncResult = {
+				success: false,
+				message:
+					error instanceof ApiError
+						? error.message
+						: 'Playlist sync failed. Check the DroppedNeedle logs.',
+				written: 0,
+				unchanged: 0,
+				removed: 0,
+				removal_failures: 0,
+				skipped_empty: 0,
+				skipped_not_ours: 0,
+				tracks_missing_files: 0,
+				tracks_unrepresentable: 0
+			};
+		} finally {
+			syncing = false;
+		}
 	}
 
 	async function save() {
@@ -130,6 +164,130 @@
 						</div>
 					</label>
 				</div>
+
+				<div class="divider"></div>
+
+				<div>
+					<h3 class="font-medium">Playlist Sync</h3>
+					<p class="text-xs text-base-content/50 mt-1 whitespace-normal">
+						Sync DroppedNeedle playlists to Navidrome - DroppedNeedle writes an
+						<code>.m3u8</code> file per playlist into a folder Navidrome scans, and refreshes them in
+						the background as playlists change.
+					</p>
+				</div>
+
+				<div class="form-control">
+					<label class="label cursor-pointer justify-start gap-4">
+						<input
+							type="checkbox"
+							bind:checked={form.data.playlist_sync_enabled}
+							class="toggle toggle-primary"
+						/>
+						<div class="whitespace-normal">
+							<span class="label-text font-medium">Export playlists to Navidrome</span>
+							<p class="text-xs text-base-content/50">
+								Nothing is written until this is on and the settings are saved
+							</p>
+						</div>
+					</label>
+				</div>
+
+				{#if form.data.playlist_sync_enabled}
+					<div class="form-control w-full">
+						<label class="label" for="navidrome-playlist-path">
+							<span class="label-text">Playlist folder</span>
+						</label>
+						<input
+							id="navidrome-playlist-path"
+							type="text"
+							bind:value={form.data.playlist_sync_path}
+							class="input input-bordered w-full"
+							placeholder="/music/playlists"
+						/>
+						<div class="label whitespace-normal">
+							<span class="label-text-alt text-base-content/50">
+								An absolute path <em>inside the DroppedNeedle container</em> that must sit
+								<strong>inside the same music library tree Navidrome scans</strong> — track paths are
+								written relative to this folder, so both apps have to see the same folder-to-track relationship.
+							</span>
+						</div>
+					</div>
+
+					<div class="form-control w-full">
+						<label class="label" for="navidrome-playlist-scope">
+							<span class="label-text">Which playlists</span>
+						</label>
+						<select
+							id="navidrome-playlist-scope"
+							bind:value={form.data.playlist_sync_scope}
+							class="select select-bordered w-full"
+						>
+							<option value="public">Public playlists only</option>
+							<option value="all">All playlists</option>
+						</select>
+						<div class="label whitespace-normal">
+							<span class="label-text-alt text-base-content/50">
+								Navidrome does not scope an imported playlist to a user, so anything exported is
+								visible to everyone on that server. "All playlists" therefore publishes other users'
+								private playlists too. To have them correctly scoped to a user on Navidrome,
+								imported playlists can be assigned to a user (and made private or public) within the
+								Navidrome dashboard.
+							</span>
+						</div>
+					</div>
+
+					<div class="form-control">
+						<label class="label cursor-pointer justify-start gap-4">
+							<input
+								type="checkbox"
+								bind:checked={form.data.playlist_sync_remove_deleted}
+								class="toggle toggle-primary"
+							/>
+							<div class="whitespace-normal">
+								<span class="label-text font-medium">
+									Remove exported files when a playlist is removed from DroppedNeedle, or when a
+									playlist is made private and only public playlists are exported
+								</span>
+								<p class="text-xs text-base-content/50">
+									Only files exported from DroppedNeedle are ever removed. Other playlists in the
+									same folder are never removed.
+								</p>
+							</div>
+						</label>
+					</div>
+
+					{#if syncResult}
+						<div
+							class="alert"
+							class:alert-success={syncResult.success}
+							class:alert-error={!syncResult.success}
+						>
+							<div class="min-w-0 whitespace-normal break-words">
+								<span>{syncResult.message}</span>
+								{#if syncResult.removal_failures}
+									<p class="text-xs mt-1">
+										Files that could not be removed are still visible in Navidrome. They will be
+										retried on the next sync — check the folder's permissions if this persists.
+									</p>
+								{/if}
+							</div>
+						</div>
+					{/if}
+
+					<div class="flex justify-start">
+						<button
+							type="button"
+							class="btn btn-outline btn-sm"
+							onclick={syncPlaylists}
+							disabled={syncing || form.saving || !form.data.playlist_sync_path}
+						>
+							{#if syncing}
+								<span class="loading loading-spinner loading-sm"></span>
+							{/if}
+							Sync Now
+						</button>
+					</div>
+				{/if}
 
 				{#if form.message}
 					<div

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -794,11 +794,30 @@ export type JellyfinTrackPage = {
 	limit: number;
 };
 
+export type NavidromePlaylistSyncScope = 'public' | 'all';
+
 export type NavidromeConnectionSettings = {
 	navidrome_url: string;
 	username: string;
 	password: string;
 	enabled: boolean;
+	playlist_sync_enabled: boolean;
+	playlist_sync_path: string;
+	playlist_sync_scope: NavidromePlaylistSyncScope;
+	playlist_sync_remove_deleted: boolean;
+};
+
+export type NavidromePlaylistSyncResult = {
+	success: boolean;
+	message: string;
+	written: number;
+	unchanged: number;
+	removed: number;
+	removal_failures: number;
+	skipped_empty: number;
+	skipped_not_ours: number;
+	tracks_missing_files: number;
+	tracks_unrepresentable: number;
 };
 
 export type NavidromeTrackInfo = {


### PR DESCRIPTION
Navidrome has no API for creating playlists, so a playlist made in DroppedNeedle cannot reach it. Navidrome does import playlist files found while scanning (ND_PLAYLISTSPATH, enabled by ND_AUTOIMPORTPLAYLISTS), so this adds an opt-in one-way export writing one .m3u8 per playlist into a directory both applications can see, refreshed by a background task and by a Sync Now button.

Settings live on the existing Navidrome connection object and inherit the admin guard on /settings:

  playlist_sync_enabledoff             by default; nothing is written until set
  playlist_sync_path                       absolute path inside the DroppedNeedle container
  playlist_sync_scope                     public | all
  playlist_sync_remove_deleted   whether superseded exports are cleaned up

Entries are relative to the playlist file's own directory. local_tracks stores an absolute file_path from DroppedNeedle's view, which is not Navidrome's when the two mount the library at different points; a relative entry resolves identically for both, including on Windows hosts. Separators are normalised to '/'. A track that cannot be expressed relative to the playlist folder (a different Windows drive) is counted and reported rather than emitted as an absolute path that would only resolve by luck. The folder must sit inside the library tree Navidrome scans, and the UI says so.

Scope defaults to public because Navidrome does not scope an imported playlist to a user: everything exported is visible to every Navidrome user. "all" also publishes other users' private playlists, so it is opt-in and the UI explains why.

Every exported file carries a '#DROPPEDNEEDLE-PLAYLIST-ID:' marker, and both overwriting and deleting require it to match, so a playlist file the user created by hand is never touched even if its name collides. Nothing is stored between runs: what we own is read back from the directory each time. An index file could go missing, be truncated or be edited, and a playlist deleted meanwhile would then have no cleanup candidate and stay readable in Navidrome indefinitely. Reading ownership back also makes a failed deletion self-correcting, since the file is still present, still ours and still ineligible on the next run.

Failure is never deletion: a playlist whose export fails keeps its file, and only playlists confirmed to no longer qualify are removed. A removal that could not happen fails the run, logs at error level and surfaces in the API and UI, and is retried on every subsequent run until it succeeds.

Each run renders every playlist and compares the text with the file on disk; identical content is left alone, so a steady library writes nothing and provokes no rescan. Writes go through a unique temporary file and os.replace so a scan cannot observe a half-written playlist, and sync holds a per-service lock so the manual and periodic paths cannot interleave. Control characters in names, metadata and rendered paths are collapsed, since M3U is line-oriented and has no escaping.

Tests cover filename portability, relative rendering, both scopes, the empty and unowned skips, rename cleanup, removal retry and reporting, recovery with no prior state, concurrency, and unchanged-file behaviour.

## What

## Why

## Testing

- [X] I have tested these changes locally
- [ ] I have added or updated tests

## AI-Assisted Contributions

Claude code was used to write this code.

## Checklist

- [X] Backend lint passes (`make backend-lint`)
- [ ] Backend tests pass (`make backend-test`)
- [ ] Frontend lint passes (`make frontend-lint`)
- [ ] Frontend type check passes (`make frontend-check`)
- [X] No `any` in TypeScript
- [X] No hardcoded colors (design tokens only)
- [X] All external API calls have timeouts
- [X] New msgspec structs follow existing patterns
- [ ] TanStack Query used for all new data fetching
- [X] No secrets, tokens, or credentials in source
