### PR TITLE
fix(docker): serve the app over IPv6 as well as IPv4

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,12 @@ Everything user-editable lives in the web UI and lands in `config/config.json`. 
 | `PGID` | `1000` | File group inside the container |
 | `UMASK` | `027` | Creation mask for new files; `002` for trusted group-writable media |
 | `PORT` | `8688` | Port the app listens on |
+| `BIND_HOST` | `auto` | `auto` listens on IPv4 and IPv6, dropping to IPv4 alone where IPv6 is off. Set `0.0.0.0`, `::`, or one interface IP to pin it |
+| `TRUSTED_PROXY_IPS` | `127.0.0.1,::1` | IPs/CIDRs whose `X-Forwarded-*` headers are trusted; point it at your reverse proxy, listing every address family it arrives on |
 | `TZ` | `Etc/UTC` | Container timezone |
 | `SLSKD_DOWNLOADS_PATH` | `/data/downloads/slskd` | Exact in-container path to slskd completions (the compose example uses `/data/slskd/complete`) |
+
+The app answers on IPv4 and IPv6, but Docker still has to publish the port on both. `docker port droppedneedle` should list `0.0.0.0:8688` and `[::]:8688`; if only the first appears, turn on IPv6 for the daemon (`"ipv6"` and `"ip6tables"` in `/etc/docker/daemon.json`).
 
 <details>
 <summary>Permissions and NAS notes</summary>

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -86,7 +86,7 @@ class Settings(BaseSettings):
     library_db_path: Path = Field(default=Path("/app/cache/library.db"), description="SQLite library database path")
     cover_cache_max_size_mb: int = Field(default=500, description="Maximum cover cache size in MB")
     trusted_proxy_ips: str = Field(
-        default="127.0.0.1",
+        default="127.0.0.1,::1",
         description="Comma-separated IPs/CIDRs trusted as reverse proxies for X-Forwarded-* headers. Configure the private proxy network in a reverse-proxy deployment; never use '*' on a directly reachable service.",
     )
     base_path: str = Field(

--- a/backend/infrastructure/network.py
+++ b/backend/infrastructure/network.py
@@ -1,0 +1,71 @@
+"""Bind helpers so the HTTP server answers on IPv4 and IPv6 alike."""
+
+from __future__ import annotations
+
+import os
+import socket
+from collections.abc import Callable
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+BIND_HOST_ENV = "BIND_HOST"
+IPV4_WILDCARD_HOST = "0.0.0.0"
+IPV6_WILDCARD_HOST = "::"
+LOOPBACK_PROBE_HOSTS = ("127.0.0.1", "::1")
+
+# asyncio's create_server() forces IPV6_V6ONLY on, so "::" serves IPv6 only and
+# never accepts v4-mapped peers. The empty host is the one value that makes it
+# bind a separate wildcard socket per available family.
+ALL_FAMILIES_HOST = ""
+
+_AUTO = "auto"
+
+
+def dual_stack_supported() -> bool:
+    """Bind both wildcards for real rather than trusting capability flags: with
+    net.ipv6.conf.all.disable_ipv6=1 an AF_INET6 socket still opens but refuses
+    to bind, and uvicorn exits when any listener fails."""
+    if not socket.has_ipv6:
+        return False
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as v6:
+            v6.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            v6.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+            v6.bind((IPV6_WILDCARD_HOST, 0))
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as v4:
+                v4.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                v4.bind((IPV4_WILDCARD_HOST, v6.getsockname()[1]))
+    except OSError:
+        return False
+    return True
+
+
+def resolve_bind_host() -> str:
+    configured = os.getenv(BIND_HOST_ENV, "").strip()
+    if configured and configured.lower() != _AUTO:
+        return configured
+    return ALL_FAMILIES_HOST if dual_stack_supported() else IPV4_WILDCARD_HOST
+
+
+class _IPv6ThreadingHTTPServer(ThreadingHTTPServer):
+    address_family = socket.AF_INET6
+
+
+class _DualStackThreadingHTTPServer(_IPv6ThreadingHTTPServer):
+    def server_bind(self) -> None:
+        self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+        super().server_bind()
+
+
+def wildcard_http_server(
+    port: int, handler: Callable[..., BaseHTTPRequestHandler]
+) -> ThreadingHTTPServer:
+    """ThreadingHTTPServer takes a single address, so one IPV6_V6ONLY-off socket
+    stands in for the pair asyncio would open for ``ALL_FAMILIES_HOST``."""
+    host = resolve_bind_host()
+    if host == ALL_FAMILIES_HOST:
+        try:
+            return _DualStackThreadingHTTPServer((IPV6_WILDCARD_HOST, port), handler)
+        except OSError:
+            host = IPV4_WILDCARD_HOST
+    server_class = _IPv6ThreadingHTTPServer if ":" in host else ThreadingHTTPServer
+    return server_class((host, port), handler)

--- a/backend/maintenance/automatic_upgrade.py
+++ b/backend/maintenance/automatic_upgrade.py
@@ -19,13 +19,18 @@ import uuid
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 from threading import Thread
 from typing import Any
 
 from core.config import Settings, get_settings, migrate_legacy_config
 from infrastructure.file_utils import atomic_write_json
+from infrastructure.network import (
+    LOOPBACK_PROBE_HOSTS,
+    resolve_bind_host,
+    wildcard_http_server,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +96,7 @@ def _upgrade_health_server(port: int, base_path: str):
     handler = functools.partial(
         _UpgradeHealthHandler, health_path=f"{base_path}/health"
     )
-    server = ThreadingHTTPServer(("0.0.0.0", port), handler)
+    server = wildcard_http_server(port, handler)
     thread = Thread(target=server.serve_forever, name="upgrade-health", daemon=True)
     thread.start()
     try:
@@ -2180,8 +2185,8 @@ def _config_path_before_settings() -> Path:
     return root / "config" / "config.json"
 
 
-def _target_ready(port: int, base_path: str) -> bool:
-    connection = http.client.HTTPConnection("127.0.0.1", port, timeout=1)
+def _health_ok(host: str, port: int, base_path: str) -> bool:
+    connection = http.client.HTTPConnection(host, port, timeout=1)
     try:
         connection.request("GET", f"{base_path}/health")
         response = connection.getresponse()
@@ -2191,6 +2196,10 @@ def _target_ready(port: int, base_path: str) -> bool:
         return False
     finally:
         connection.close()
+
+
+def _target_ready(port: int, base_path: str) -> bool:
+    return any(_health_ok(host, port, base_path) for host in LOOPBACK_PROBE_HOSTS)
 
 
 def _admission_paths(settings: Settings, token: str) -> tuple[Path, Path]:
@@ -2293,7 +2302,7 @@ def _target_command(port: int) -> list[str]:
         "uvicorn",
         "target_main:app",
         "--host",
-        "0.0.0.0",
+        resolve_bind_host(),
         "--port",
         str(port),
         "--loop",

--- a/backend/target_application.py
+++ b/backend/target_application.py
@@ -847,10 +847,13 @@ def create_production_target_application() -> FastAPI:
             allow_origins=[
                 "http://localhost:5173",
                 "http://127.0.0.1:5173",
+                "http://[::1]:5173",
                 "http://localhost:4173",
                 "http://127.0.0.1:4173",
+                "http://[::1]:4173",
                 "http://localhost:3000",
                 "http://127.0.0.1:3000",
+                "http://[::1]:3000",
             ],
             allow_credentials=True,
             allow_methods=["*"],

--- a/backend/tests/infrastructure/test_automatic_upgrade.py
+++ b/backend/tests/infrastructure/test_automatic_upgrade.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, MagicMock
 import maintenance.automatic_upgrade as automatic_upgrade
 
 from core.config import Settings
+from infrastructure.network import dual_stack_supported, resolve_bind_host
 from maintenance.automatic_upgrade import (
     AutomaticUpgradeError,
     UPGRADE_ID,
@@ -795,16 +796,20 @@ def test_docker_image_runs_automatic_upgrade_before_target_application() -> None
     )
     assert "find /app -type f" in dockerfile
     assert "find /app/backend" not in dockerfile
-    assert automatic_upgrade._target_command(8688)[-2:] == ["--workers", "1"]
+    command = automatic_upgrade._target_command(8688)
+    assert command[-2:] == ["--workers", "1"]
+    assert command[command.index("--host") + 1] == resolve_bind_host()
 
 
 def test_upgrade_health_endpoint_keeps_existing_orchestrators_waiting() -> None:
     port = _free_port()
+    hosts = ["127.0.0.1", "[::1]"] if dual_stack_supported() else ["127.0.0.1"]
 
     with _upgrade_health_server(port, ""):
-        with urlopen(f"http://127.0.0.1:{port}/health", timeout=2) as response:
-            assert response.status == 200
-            assert json.loads(response.read()) == {"status": "upgrading"}
+        for host in hosts:
+            with urlopen(f"http://{host}:{port}/health", timeout=2) as response:
+                assert response.status == 200
+                assert json.loads(response.read()) == {"status": "upgrading"}
         with pytest.raises(HTTPError) as error:
             urlopen(f"http://127.0.0.1:{port}/api/v1/library", timeout=2)
 

--- a/backend/tests/infrastructure/test_network.py
+++ b/backend/tests/infrastructure/test_network.py
@@ -1,0 +1,164 @@
+import socket
+import subprocess
+import sys
+import time
+from http.server import BaseHTTPRequestHandler
+from pathlib import Path
+from threading import Thread
+from urllib.request import urlopen
+
+import pytest
+
+from infrastructure import network
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        self.send_response(200)
+        self.send_header("Content-Length", "2")
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, _format: str, *args: object) -> None:
+        return
+
+
+def _free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def test_bind_host_defaults_to_every_family_when_both_wildcards_bind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(network.BIND_HOST_ENV, raising=False)
+    monkeypatch.setattr(network, "dual_stack_supported", lambda: True)
+
+    assert network.resolve_bind_host() == ""
+
+
+def test_bind_host_falls_back_to_ipv4_when_ipv6_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(network.BIND_HOST_ENV, raising=False)
+    monkeypatch.setattr(network, "dual_stack_supported", lambda: False)
+
+    assert network.resolve_bind_host() == "0.0.0.0"
+
+
+@pytest.mark.parametrize("configured", ["0.0.0.0", "::1", "192.168.1.5"])
+def test_bind_host_honours_an_explicit_override(
+    monkeypatch: pytest.MonkeyPatch, configured: str
+) -> None:
+    monkeypatch.setenv(network.BIND_HOST_ENV, configured)
+    monkeypatch.setattr(network, "dual_stack_supported", lambda: True)
+
+    assert network.resolve_bind_host() == configured
+
+
+def test_bind_host_treats_auto_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(network.BIND_HOST_ENV, " AUTO ")
+    monkeypatch.setattr(network, "dual_stack_supported", lambda: False)
+
+    assert network.resolve_bind_host() == "0.0.0.0"
+
+
+@pytest.mark.skipif(
+    not network.dual_stack_supported(), reason="host has no dual-stack IPv6"
+)
+def test_wildcard_server_answers_on_both_families(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(network.BIND_HOST_ENV, raising=False)
+    port = _free_port()
+    server = network.wildcard_http_server(port, _Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        for host in ("127.0.0.1", "[::1]"):
+            with urlopen(f"http://{host}:{port}/", timeout=2) as response:
+                assert response.status == 200
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_wildcard_server_falls_back_when_ipv6_bind_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(network.BIND_HOST_ENV, raising=False)
+    monkeypatch.setattr(network, "dual_stack_supported", lambda: True)
+
+    def refuse(*_args: object, **_kwargs: object):
+        raise OSError("IPv6 unavailable")
+
+    monkeypatch.setattr(network, "_DualStackThreadingHTTPServer", refuse)
+    port = _free_port()
+    server = network.wildcard_http_server(port, _Handler)
+    try:
+        assert server.socket.family == socket.AF_INET
+    finally:
+        server.server_close()
+
+
+def test_wildcard_server_honours_an_explicit_ipv6_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(network.BIND_HOST_ENV, "::1")
+    server = network.wildcard_http_server(_free_port(), _Handler)
+    try:
+        assert server.socket.family == socket.AF_INET6
+    finally:
+        server.server_close()
+
+
+@pytest.mark.skipif(
+    not network.dual_stack_supported(), reason="host has no dual-stack IPv6"
+)
+def test_uvicorn_serves_both_families_on_the_resolved_bind_host(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plausible-looking "::" passes every unit check above and still refuses
+    every IPv4 client, so pin the choice against uvicorn's real socket setup."""
+    monkeypatch.delenv(network.BIND_HOST_ENV, raising=False)
+    (tmp_path / "stub_asgi.py").write_text(
+        "async def app(scope, receive, send):\n"
+        "    if scope['type'] != 'http':\n"
+        "        return\n"
+        "    await send({'type': 'http.response.start', 'status': 200, 'headers': []})\n"
+        "    await send({'type': 'http.response.body', 'body': b'ok'})\n",
+        encoding="utf-8",
+    )
+    port = _free_port()
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "stub_asgi:app",
+            "--host",
+            network.resolve_bind_host(),
+            "--port",
+            str(port),
+            "--log-level",
+            "warning",
+        ],
+        cwd=tmp_path,
+    )
+    try:
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            assert process.poll() is None, "uvicorn exited before binding"
+            try:
+                urlopen(f"http://127.0.0.1:{port}/", timeout=1).close()
+                break
+            except OSError:
+                time.sleep(0.1)
+        for host in ("127.0.0.1", "[::1]"):
+            with urlopen(f"http://{host}:{port}/", timeout=5) as response:
+                assert response.status == 200
+    finally:
+        process.terminate()
+        process.wait(timeout=15)

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -17,9 +17,10 @@ services:
       - PORT=8688            # must match the container port under "ports"
       - TZ=Etc/UTC           # e.g. America/New_York, Europe/London
       - SLSKD_DOWNLOADS_PATH=/data/slskd/complete  # path inside the common media mount below
-      # - TRUSTED_PROXY_IPS=172.17.0.1  # your reverse proxy's IP; defaults to * (fine for single-host)
+      # - BIND_HOST=auto      # dual-stack (IPv4 + IPv6) listener; set 0.0.0.0 to pin IPv4 only
+      # - TRUSTED_PROXY_IPS=172.17.0.1  # your reverse proxy's IP/CIDR; defaults to the loopbacks 127.0.0.1,::1
     ports:
-      - "8688:8688"          # host:container
+      - "8688:8688"          # host:container; publishes on IPv4 and IPv6 when the Docker daemon has IPv6 enabled
     volumes:
       - ./config:/app/config       # config + database
       - ./cache:/app/cache         # cover art and metadata cache


### PR DESCRIPTION
## What/Why

The container start command pinned uvicorn to `--host 0.0.0.0`, so the API was unreachable over IPv6 wherever the client family survives to the container: network_mode host, IPv6-enabled bridge/macvlan networks, and daemons running with userland-proxy disabled. For me personally, this interfered with my ability to run droppedneedle in an ipv6-only k8s cluster.

Bind every available address family instead. The host is resolved at startup by `infrastructure.network`, which probes an actual dual-wildcard bind rather than trusting socket.has_dualstack_ipv6(); a container run with net.ipv6.conf.all.disable_ipv6=1 still opens AF_INET6 sockets but refuses to bind them, and uvicorn exits when a listener fails. When the probe fails the host falls back to 0.0.0.0, and BIND_HOST overrides the whole decision.

## Testing

The resolved host is the empty string, not "::": asyncio's `create_server()` unconditionally sets `IPV6_V6ONLY`, so "::" would have served IPv6 only and silently dropped every IPv4 client. Only the empty host makes asyncio open a separate wildcard socket per family. A test spawns real `uvicorn` and asserts both loopbacks answer, so the distinction cannot be refactored away.

Also reached by the same assumption:

- the pre-upgrade health server bound a bare IPv4 `ThreadingHTTPServer`, and the target readiness probe only polled 127.0.0.1
- `trusted_proxy_ips` defaulted to 127.0.0.1, leaving a proxy on the IPv6 loopback untrusted for X-Forwarded-*
- the debug CORS allowlist covered localhost and 127.0.0.1 but not [::1]

The compose example's TRUSTED_PROXY_IPS comment claimed a default of '*', which was never true; corrected alongside the new BIND_HOST documentation.

- [x] I have tested these changes locally
- [x] I have added or updated tests

## AI-Assisted Contributions

If any part of this PR was generated or assisted by AI (Copilot, ChatGPT, etc.), please describe which sections and how the AI was used. See `CONTRIBUTING.md` for the full policy.

AI was used to assist with automated testing and writing documentation.

## Checklist

- [ ] Backend lint passes (`make backend-lint`)
- [ ] Backend tests pass (`make backend-test`)
- [ ] Frontend lint passes (`make frontend-lint`)
- [ ] Frontend type check passes (`make frontend-check`)
- [ ] No `any` in TypeScript
- [ ] No hardcoded colors (design tokens only)
- [ ] All external API calls have timeouts
- [ ] New msgspec structs follow existing patterns
- [ ] TanStack Query used for all new data fetching
- [ ] No secrets, tokens, or credentials in source
