### PR TITLE
Preserve file extensions when truncating management paths

### DIFF
--- a/backend/services/native/naming.py
+++ b/backend/services/native/naming.py
@@ -267,7 +267,12 @@ class NamingTemplateEngine:
                 column=1,
             )
         cleaned = tuple(
-            self._clean_management_component(part, compatibility) for part in parts
+            self._clean_management_component(
+                part,
+                compatibility,
+                preserve_suffix=(index == len(parts) - 1),
+            )
+            for index, part in enumerate(parts)
         )
         relative = "/".join(cleaned)
         encoded_length = len(relative.encode("utf-8"))
@@ -334,7 +339,12 @@ class NamingTemplateEngine:
                 column=1,
             )
         cleaned = tuple(
-            self._clean_management_component(part, compatibility) for part in parts
+            self._clean_management_component(
+                part,
+                compatibility,
+                preserve_suffix=(index == len(parts) - 1),
+            )
+            for index, part in enumerate(parts)
         )
         relative = "/".join(cleaned)
         encoded_length = len(relative.encode("utf-8"))
@@ -574,6 +584,8 @@ class NamingTemplateEngine:
         cls,
         component: str,
         compatibility: PathCompatibilitySettings,
+        *,
+        preserve_suffix: bool = False,
     ) -> str:
         replacement = compatibility.separator_replacement
         cleaned = unicodedata.normalize(compatibility.unicode_normalization, component)
@@ -601,12 +613,41 @@ class NamingTemplateEngine:
         encoded = cleaned.encode("utf-8")
         maximum = compatibility.maximum_component_length
         if len(encoded) > maximum:
-            cleaned = encoded[:maximum].decode("utf-8", "ignore")
-            cleaned = (
-                cleaned.strip(" .") if compatibility.windows_compatible else cleaned
-            )
-            if not cleaned:
-                cleaned = replacement
+            if preserve_suffix:
+                suffix = Path(cleaned).suffix
+                suffix_bytes = suffix.encode("utf-8")
+                if (
+                    suffix
+                    and len(suffix_bytes) < maximum
+                    and cleaned.endswith(suffix)
+                ):
+                    stem = cleaned[: -len(suffix)]
+                    budget = maximum - len(suffix_bytes)
+                    truncated_stem = (
+                        stem.encode("utf-8")[:budget].decode("utf-8", "ignore")
+                    )
+                    if compatibility.windows_compatible:
+                        truncated_stem = truncated_stem.rstrip(" .")
+                    candidate = f"{truncated_stem}{suffix}"
+                    if not candidate:
+                        candidate = replacement
+                    cleaned = candidate
+                else:
+                    cleaned = encoded[:maximum].decode("utf-8", "ignore")
+                    cleaned = (
+                        cleaned.strip(" .")
+                        if compatibility.windows_compatible
+                        else cleaned
+                    )
+                    if not cleaned:
+                        cleaned = replacement
+            else:
+                cleaned = encoded[:maximum].decode("utf-8", "ignore")
+                cleaned = (
+                    cleaned.strip(" .") if compatibility.windows_compatible else cleaned
+                )
+                if not cleaned:
+                    cleaned = replacement
             if (
                 compatibility.windows_compatible
                 and cleaned.split(".", 1)[0].casefold() in _RESERVED_NAMES

--- a/backend/tests/services/native/test_management_suffix_truncation.py
+++ b/backend/tests/services/native/test_management_suffix_truncation.py
@@ -1,0 +1,189 @@
+"""Regression tests for suffix-preserving component truncation.
+
+Covers the fix for the AudioWriteError cluster caused by
+``_clean_management_component`` trimming the file extension when a
+management path component exceeds ``maximum_component_length``.
+
+The real-world failure surface: a destination basename like
+``..._01_Symphony no. 35 ..._ I. Allegro con spirito.flac`` (>= 240 UTF-8
+bytes) was truncated blindly on the decode boundary, mangling the suffix
+into something like ``. Allegro con spir`` so the staged artifact was not
+recognised as an admitted audio format.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from api.v1.schemas.library_management import PathCompatibilitySettings
+from services.native.naming import NamingTemplateEngine
+
+
+def _compat(**overrides) -> PathCompatibilitySettings:
+    base = dict(
+        windows_compatible=True,
+        replace_non_ascii=False,
+        replace_spaces_with_underscores=False,
+        separator_replacement="_",
+        maximum_component_length=240,
+        maximum_path_length=4096,
+        unicode_normalization="NFC",
+        extension_case="preserve",
+        windows_legacy_path_limit=False,
+    )
+    base.update(overrides)
+    return PathCompatibilitySettings(**base)
+
+
+def _literal_artist_dir() -> str:
+    # Directory component: must never be treated as a file extension even
+    # when it contains dots (e.g. "Symphony no. 2 ...").
+    return "Gustav Mahler - Symphony no. 2 “Resurrection”"
+
+
+@pytest.fixture
+def engine() -> NamingTemplateEngine:
+    return NamingTemplateEngine()
+
+
+def _name(result) -> str:
+    return result.relative_path.rsplit("/", 1)[-1]
+
+
+def test_short_filename_unchanged(engine) -> None:
+    compat = _compat()
+    result = engine.format_management_literal_path(
+        f"{_literal_artist_dir()}/A Short Title.flac", compat
+    )
+    assert result.relative_path == (
+        f"{_literal_artist_dir()}/A Short Title.flac"
+    )
+
+
+def test_flac_over_240_bytes_keeps_suffix(engine) -> None:
+    stem = "Symphony no. 35 in D major, K. 385 Haffner - I. Allegro con spirito"
+    # inflate so the full name clearly exceeds 240 UTF-8 bytes
+    inflated = (stem + " ") * 4 + stem
+    name = f"{inflated}.flac"
+    assert len(name.encode("utf-8")) > 240
+    result = engine.format_management_literal_path(
+        f"{_literal_artist_dir()}/{name}", _compat()
+    )
+    out_name = _name(result)
+    assert len(out_name.encode("utf-8")) <= 240
+    assert out_name.endswith(".flac")
+    assert Path(out_name).suffix == ".flac"
+    assert not out_name.endswith(". Allegro")
+
+
+def test_flac_internal_dots_never_used_as_suffix(engine) -> None:
+    stem = "Symphony no. 35 in D major, K. 385 Haffner - I. Allegro con spirito"
+    inflated = (stem + " ") * 4 + stem
+    name = f"{inflated}.flac"
+    result = engine.format_management_literal_path(
+        f"{_literal_artist_dir()}/{name}", _compat()
+    )
+    out_name = _name(result)
+    assert Path(out_name).suffix == ".flac"
+    # the naive pre-fix path used ". Allegro con spir"; guarantee it is gone
+    assert not out_name.split(".flac")[0].endswith(". Allegro con spir")
+
+
+def test_utf8_multibyte_preserved_and_valid(engine) -> None:
+    # ó ü – etc. must survive truncation; output must be <= 240 bytes, valid
+    # UTF-8, and keep ".flac".
+    long_title = (
+        "Ópera – Variaciones sobre un tema de Paganini, op. 38 "
+        "– Estudio nº 12 “Le Streghe” – Scherzo en si bemol mayor – "
+        "Rapsodia española – La Campanella – Mephisto Waltz"
+    )
+    inflated = (long_title + " ") * 3 + long_title
+    name = f"{inflated}.flac"
+    assert len(name.encode("utf-8")) > 240
+    result = engine.format_management_literal_path(
+        f"{_literal_artist_dir()}/{name}", _compat()
+    )
+    out_name = _name(result)
+    out_bytes = out_name.encode("utf-8")
+    assert len(out_bytes) <= 240
+    out_bytes.decode("utf-8")  # must be valid UTF-8, raises otherwise
+    assert out_name.endswith(".flac")
+
+
+def test_long_internal_directory_with_dots_keeps_dot_contents(engine) -> None:
+    # Intermediate dir with lots of dots must NOT be treated as an extension
+    # nor get its own suffix preserved logic applied.
+    compat = _compat(maximum_component_length=60)
+    dir_name = "Gustav Mahler - Symphony no. 2 “Resurrection” - Live in Vienna"
+    result = engine.format_management_literal_path(
+        f"{dir_name}/track.flac", compat
+    )
+    first = result.relative_path.split("/")[0]
+    assert len(first.encode("utf-8")) <= 60
+    assert Path(result.relative_path).name == "track.flac"
+
+
+@pytest.mark.parametrize(
+    "extension",
+    [".mp3", ".m4a", ".opus", ".ogg", ".wav"],
+)
+def test_other_audio_extensions_preserved(engine, extension) -> None:
+    stem = "A rather long track title that keeps going and going"
+    inflated = (stem + " ") * 5 + stem
+    name = f"{inflated}{extension}"
+    assert len(name.encode("utf-8")) > 240
+    result = engine.format_management_literal_path(
+        f"{_literal_artist_dir()}/{name}", _compat()
+    )
+    out_name = _name(result)
+    assert len(out_name.encode("utf-8")) <= 240
+    assert out_name.endswith(extension)
+
+
+def test_literal_sidecar_lrc_preserved(engine) -> None:
+    stem = (
+        "Assassin's Creed Valhalla - Some impossibly long lyrical track name "
+        "that is designed to blow way past the component limit and overflow"
+    )
+    inflated = (stem + " ") * 3 + stem
+    name = f"{inflated}.lrc"
+    assert len(name.encode("utf-8")) > 240
+    result = engine.format_management_literal_path(
+        f"{_literal_artist_dir()}/{name}", _compat()
+    )
+    out_name = _name(result)
+    assert len(out_name.encode("utf-8")) <= 240
+    assert out_name.endswith(".lrc")
+
+
+def test_literal_sidecar_jpg_preserved(engine) -> None:
+    name = f"{'x' * 250}.jpg"
+    result = engine.format_management_literal_path(
+        f"Artist/Album ({2020})/{name}", _compat()
+    )
+    out_name = _name(result)
+    assert len(out_name.encode("utf-8")) <= 240
+    assert out_name.endswith(".jpg")
+
+
+def test_boundary_exact_240_untouched(engine) -> None:
+    # At exactly the limit there is no truncation at all.
+    name = "a" * 235 + ".flac"  # 235 + 5 = 240 bytes
+    assert len(name.encode("utf-8")) == 240
+    result = engine.format_management_literal_path(
+        f"Artist/{name}", _compat()
+    )
+    assert _name(result) == name
+    assert len(_name(result).encode("utf-8")) == 240
+
+
+def test_just_over_240_truncates_stem_not_suffix(engine) -> None:
+    # 241 bytes total: the stem is trimmed, the ".flac" suffix is kept.
+    name = "a" * 236 + ".flac"  # 241 bytes
+    assert len(name.encode("utf-8")) == 241
+    result = engine.format_management_literal_path(
+        f"Artist/{name}", _compat()
+    )
+    out_name = _name(result)
+    assert len(out_name.encode("utf-8")) == 240
+    assert out_name.endswith(".flac")


### PR DESCRIPTION
## What

Preserve file extensions when Library Management truncates the final path
component to `maximum_component_length`.

Previously, long filenames were truncated byte-wise from the end, which could
remove the real file extension. The change reserves space for the existing
suffix and truncates only the filename stem.

The suffix-preserving behavior is only applied to the final path component, so
intermediate directories containing periods are not treated as filenames.

Regression tests were added for long filenames, internal periods, multibyte
UTF-8 characters, multiple audio extensions, and literal management paths.

## Why

Library Management uses the suffix of the planned destination when creating its
temporary staging artifact.

When a long destination filename exceeded `maximum_component_length` (240 bytes
with the default profile), the existing truncation logic could remove `.flac`
and leave a period from the track title as the apparent suffix.

For example, a valid destination ending in:

`... Symphony no. 35 ... - I. Allegro con spirito.flac`

could be truncated so that `Path.suffix` became something like:

`. Allegro con spir`

The staged file still contained valid FLAC data, but
`AudioMetadataEngine.read()` rejected it because the extension was not an
admitted audio extension, resulting in:

`UnsupportedAudioFormatError: The file does not have an admitted, detectable audio format.`

This was reproduced in a real Library Management operation:

- 21 publication bundles had failed with `AudioWriteError`
- 447 audio plan items were analysed
- 126 planned destinations had lost or acquired an invalid suffix after truncation
- all 21 failed bundles contained at least one affected item

After the fix, fresh previews produced zero invalid audio suffixes.

The fix was then validated end-to-end:

- one affected bundle was applied independently first
- the remaining 20 affected bundles were processed in four batches
- 438 schedulable audio items were published
- all Apply operations completed with `failed=0` and `skipped=0`
- recovery diagnostics remained clean after every batch
- 9 unrelated `PATH_COLLISION_DIFFERENT` items were correctly blocked during planning and were not forced

## Testing

- [x] I have tested these changes locally
- [x] I have added or updated tests

Targeted regression and naming tests pass.

`make backend-test` was also run. Three unrelated benchmark tests fail on my
local macOS environment, with the same failures reproduced against upstream
`main`:

- `test_target_scan_benchmark_exercises_incremental_stack`
- `test_migration_handoff_scan_reuses_the_migrated_database`
- `test_box_set_network_unavailable_and_control_benchmarks`

Regression coverage includes:

- long filenames preserving `.flac`
- filenames containing internal periods
- UTF-8/multibyte characters at the truncation boundary
- intermediate directories containing periods
- filenames that do not require truncation
- `.mp3`, `.m4a`, `.opus`, `.ogg`, and other suffixes
- literal management paths / sidecar filenames
- end-to-end Library Management preview and Apply validation against the originally affected files

## AI-Assisted Contributions

AI tools (ChatGPT and an AI coding agent) assisted with root-cause analysis,
diagnostic planning, implementation of the suffix-preserving truncation change,
and regression-test generation.

I reviewed the resulting code and tests and validated the change against the
original failure cases, including end-to-end Library Management Apply
operations.

## Checklist

- [x] Backend lint passes (`make backend-lint`)
- [ ] Backend tests pass (`make backend-test`) — 3 unrelated benchmark failures reproduced on upstream/main
- [ ] Frontend lint passes (`make frontend-lint`) — not run; backend-only change
- [ ] Frontend type check passes (`make frontend-check`) — not run; backend-only change
- [x] No `any` in TypeScript
- [x] No hardcoded colors (design tokens only)
- [x] All external API calls have timeouts
- [x] New msgspec structs follow existing patterns
- [x] TanStack Query used for all new data fetching
- [x] No secrets, tokens, or credentials in source